### PR TITLE
Add keywords filter

### DIFF
--- a/mapBuilder/locales/en_US/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/en_US/dictionary.UTF-8.properties
@@ -12,3 +12,4 @@ layer.deleted=Layer deleted.
 error.api.inkmap=API key missing.
 filter.button.no=No filter
 filter.button.extent=Filter by extent
+filter.button.keywords=Filter by keywords

--- a/mapBuilder/locales/en_US/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/en_US/dictionary.UTF-8.properties
@@ -13,3 +13,4 @@ error.api.inkmap=API key missing.
 filter.button.no=No filter
 filter.button.extent=Filter by extent
 filter.button.keywords=Filter by keywords
+filter.keywords.list=Show keywords list

--- a/mapBuilder/locales/en_US/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/en_US/dictionary.UTF-8.properties
@@ -10,3 +10,5 @@ geobookmark.deleted=Map deleted.
 layer.added=Layer added.
 layer.deleted=Layer deleted.
 error.api.inkmap=API key missing.
+filter.button.no=No filter
+filter.button.extent=Filter by extent

--- a/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
@@ -13,3 +13,4 @@ error.api.inkmap=Clé API manquante.
 filter.button.no=Pas de filtre
 filter.button.extent=Filtrer par emprise
 filter.button.keywords=Filtrer par mots-clés
+filter.keywords.list=Afficher la liste des mots-clés

--- a/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
@@ -12,3 +12,4 @@ layer.deleted=Couche supprimée.
 error.api.inkmap=Clé API manquante.
 filter.button.no=Pas de filtre
 filter.button.extent=Filtrer par emprise
+filter.button.keywords=Filtrer par mots-clés

--- a/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
@@ -10,3 +10,5 @@ geobookmark.deleted=Carte supprimée.
 layer.added=Couche ajoutée.
 layer.deleted=Couche supprimée.
 error.api.inkmap=Clé API manquante.
+filter.button.no=Pas de filtre
+filter.button.extent=Filtrer par emprise

--- a/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
@@ -12,3 +12,4 @@ layer.deleted=Camada eliminada
 error.api.inkmap=Chave de API em falta.
 filter.button.no=Sem filtro
 filter.button.extent=Filtrar por extensão
+filter.button.keywords=Filtrar por palavras-chave

--- a/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
@@ -13,3 +13,4 @@ error.api.inkmap=Chave de API em falta.
 filter.button.no=Sem filtro
 filter.button.extent=Filtrar por extensão
 filter.button.keywords=Filtrar por palavras-chave
+filter.keywords.list=Mostrar lista de palavras-chave

--- a/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
@@ -10,3 +10,5 @@ geobookmark.deleted=Mapa eliminado
 layer.added=Camada adicionada
 layer.deleted=Camada eliminada
 error.api.inkmap=Chave de API em falta.
+filter.button.no=Sem filtro
+filter.button.extent=Filtrar por extensão

--- a/mapBuilder/templates/main.tpl
+++ b/mapBuilder/templates/main.tpl
@@ -102,7 +102,14 @@
         <span id="layers-loading"></span>
       </div>
       <div id="layerStoreHolder">
-
+        <div id="filterButtons" class="btn-group-toggle" data-toggle="buttons">
+          <label class="btn btn-secondary btn-sm active"  id="filterButtonNo">
+            <input type="radio" name="No" autocomplete="off" checked> {@mapBuilder~dictionary.filter.button.no@}
+          </label>
+          <label class="btn btn-secondary btn-sm" id="filterButtonExtent">
+            <input type="radio" name="Extent" autocomplete="off"> {@mapBuilder~dictionary.filter.button.extent@}
+          </label>
+        </div>
       </div>
       <div id="baseLayer">
         {@view~map.baselayermenu.title@}

--- a/mapBuilder/templates/main.tpl
+++ b/mapBuilder/templates/main.tpl
@@ -115,7 +115,7 @@
         </div>
         <div id="filterKeywordsHandler">
           <button id="filterKeywordsListButton" type="button" class="btn btn-sm btn-info dropdown-toggle">
-            Show keywords list
+            {@mapBuilder~dictionary.filter.keywords.list@}
           </button>
           <div id="filterKeywordsList" class="">
           </div>

--- a/mapBuilder/templates/main.tpl
+++ b/mapBuilder/templates/main.tpl
@@ -109,6 +109,16 @@
           <label class="btn btn-secondary btn-sm" id="filterButtonExtent">
             <input type="radio" name="Extent" autocomplete="off"> {@mapBuilder~dictionary.filter.button.extent@}
           </label>
+          <label class="btn btn-secondary btn-sm" id="filterButtonKeywords">
+            <input type="radio" name="Keywords" autocomplete="off"> {@mapBuilder~dictionary.filter.button.keywords@}
+          </label>
+        </div>
+        <div id="filterKeywordsHandler">
+          <button id="filterKeywordsListButton" type="button" class="btn btn-sm btn-info dropdown-toggle">
+            Show keywords list
+          </button>
+          <div id="filterKeywordsList" class="">
+          </div>
         </div>
       </div>
       <div id="baseLayer">

--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -435,3 +435,17 @@ custom-slider .thumb {
     border: solid 1px #555555;
     cursor: pointer;
 }
+
+/* CSS for filtering buttons */
+
+#filterButtons {
+    display: flex;
+    justify-content: space-around;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+#filterButtons > label:first-child {
+    width: 100%;
+}

--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -208,6 +208,7 @@ span.layerStore-folder {
 
 #layerStoreHolder {
     margin: 15px 10px;
+    max-width: 40vw;
 }
 
 #layerStoreHolder ul {
@@ -444,8 +445,66 @@ custom-slider .thumb {
     margin-bottom: 12px;
     flex-wrap: wrap;
     gap: 10px;
+    cursor: pointer;
+}
+
+#filterKeywordsHandler {
+    display: none;
+    justify-content: space-around;
+    flex-wrap: wrap;
+    gap: 10px;
+    max-width: 390px;
+    margin: auto auto 12px auto;
+    width: 90%;
+}
+
+#filterKeywordsHandler.active {
+    display: flex;
 }
 
 #filterButtons > label:first-child {
     width: 100%;
+}
+
+#filterKeywordsListButton {
+    width: 100%;
+    z-index: 2;
+}
+
+#filterKeywordsList {
+    width: 100%;
+    margin-top: -20px;
+    z-index: 1;
+    padding: 5px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    font-size: .875rem;
+    border-radius: 0 0 8px 8px;
+    overflow-y: scroll;
+    max-height: 0px;
+    transition: ease 0.3s;
+}
+
+#filterKeywordsList.active {
+    max-height: 120px;
+    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.3);
+    margin-top: -12px;
+}
+
+#filterKeyword {
+    margin: 5px;
+    cursor: pointer;
+    padding: 5px 9px;
+    border-radius: 7px;
+    transition: ease 0.1s;
+}
+
+#filterKeyword:hover {
+    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.2);
+}
+
+#filterKeyword.active {
+    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.2);
+    background-color: #e2f4ff;
 }

--- a/mapBuilder/www/js/components/LayerStore.js
+++ b/mapBuilder/www/js/components/LayerStore.js
@@ -36,9 +36,14 @@ export class LayerStore extends HTMLElement {
   /**
    * Template for a folder.
    * @param {LayerTreeFolder} element The folder to render.
-   * @returns {TemplateResult<1>} The template of the folder.
+   * @returns {TemplateResult<1>|null} The template of the folder or null if the folder shouldn't be visible.
    */
   folderTemplate = (element) => {
+    if (!element.isVisible()) {
+      // We use 'null' value because "html``" is not really empty
+      return null;
+    }
+
     //Check if the folder will have to load children from a project.
     let tagLazy = element.isLazy() ? "lazy" : "";
 
@@ -77,28 +82,33 @@ export class LayerStore extends HTMLElement {
       element.getChildren().forEach(value => {
         let childTemplate;
         if (value instanceof LayerTreeFolder) {
-          childTemplate = html`
-              ${this.folderTemplate(value)}
-          `;
+          childTemplate = this.folderTemplate(value);
         } else {
-          childTemplate = html`
-              ${this.layerTemplate(value)}
-          `;
+          childTemplate = this.layerTemplate(value);
         }
-        allChildTemplate = html`
+        if (childTemplate !== null) {
+          allChildTemplate = html`
             ${allChildTemplate}
             ${childTemplate}
         `;
+        }
       });
-      template = html`
-          ${template}
-          <ul class="layerStore-tree"
-              @mouseover='${(event) => {event.target.closest("ul").style = `background-color: ${element.getHoverColor()}; transition: 0.2s;`}}' 
-              @mouseout='${(event) => {event.target.closest("ul").style = `background-color: ${element.getColor()}; transition: 0.2s;`}}' 
-              style="background-color: ${element.getColor()}">
-              ${allChildTemplate}
-          </ul>
-      `;
+      // Prevent empty 'ul' tag which are not well displayed
+      if (allChildTemplate.strings[0] !== "") {
+        template = html`
+            ${template}
+            <ul class="layerStore-tree"
+                @mouseover='${(event) => {
+                    event.target.closest("ul").style = `background-color: ${element.getHoverColor()}; transition: 0.2s;`
+                }}'
+                @mouseout='${(event) => {
+                    event.target.closest("ul").style = `background-color: ${element.getColor()}; transition: 0.2s;`
+                }}'
+                style="background-color: ${element.getColor()}">
+                ${allChildTemplate}
+            </ul>
+        `;
+      }
     }
     return template;
   }
@@ -106,9 +116,14 @@ export class LayerStore extends HTMLElement {
   /**
    * Template for a layer.
    * @param {LayerTreeLayer} element The layer to render.
-   * @returns {TemplateResult<1>} The template of the layer.
+   * @returns {TemplateResult<1>|null} The template of the layer or null if the layer element shouldn't be visible.
    */
   layerTemplate = (element) => {
+    if (!element.isVisible()) {
+      // We use 'null' value because "html``" is not really empty
+      return null;
+    }
+
     var styleOption = html``;
     element.getStyle().forEach(function (style) {
       styleOption = html`
@@ -365,6 +380,44 @@ export class LayerStore extends HTMLElement {
   getTree() {
     return this.tree;
   }
+
+  /**
+   * Update the tree.
+   * @param {[LayerTreeElement]} tree - The new tree.
+   */
+  updateTree(tree) {
+    this.tree = tree;
+    this.render();
+  }
+
+  /**
+   * Set visibility of layers from layerStore to true.
+   * Allow the layerStore to print all layers.
+   * Call a recursive function to set all layers visible.
+   * @return {[LayerTreeElement]} - The tree.
+   */
+  setAllVisible() {
+    for (let i = 0; i < this.tree.length; i++) {
+      this.recSetVisible(this.tree[i]);
+    }
+    return this.tree;
+  }
+
+  /**
+   * Recursive function to set all layers visible.
+   * @param {LayerTreeFolder|LayerTreeLayer} treeElement - Layer tree element to change visibility.
+   */
+  recSetVisible(treeElement) {
+    treeElement.setVisible(true);
+    if (treeElement instanceof LayerTreeLayer) {
+      return;
+    }
+    let children = treeElement.getChildren();
+    for (let i = 0; i < children.length; i++) {
+      this.recSetVisible(children[i]);
+    }
+  }
+
 }
 
 customElements.define('lizmap-layer-store', LayerStore);

--- a/mapBuilder/www/js/components/LayerStore.js
+++ b/mapBuilder/www/js/components/LayerStore.js
@@ -12,11 +12,13 @@ export class LayerStore extends HTMLElement {
   /**
    * Create a layer store.
    * @param {HTMLElement} container The HTMLElement where the layer store will be rendered.
+   * @param {KeywordsManager} keywordsManager The keywords manager.
    */
-  constructor(container) {
+  constructor(container, keywordsManager) {
     super();
     this.container = container;
     this.tree = [];
+    this.keywordsManager = keywordsManager;
 
     mapBuilder.layerStoreTree.forEach((value) => {
       this.tree.push(new LayerTreeFolder({
@@ -217,8 +219,19 @@ export class LayerStore extends HTMLElement {
 
     const promises = [
       new Promise(resolve => {
-          $.get(url, function (capabilities) {
+          $.get(url, (capabilities) => {
             var result = parser.read(capabilities);
+
+            const title = result["Service"]["Title"]
+            const wordList = result["Service"]["KeywordList"]
+            this.keywordsManager.addKeywordFromList(wordList);
+
+            this.tree.forEach((element) => {
+              if (element.getLazyTitle() === title) {
+                element.setKeywords(wordList);
+              }
+            });
+
             if (result.hasOwnProperty('Capability')) {
               var node = result.Capability;
 

--- a/mapBuilder/www/js/main.js
+++ b/mapBuilder/www/js/main.js
@@ -32,6 +32,9 @@ import {CustomProgress} from "./components/inkmap/ProgressBar";
 
 import {getJobStatus, queuePrint} from './dist/inkmap.js';
 
+// Filters
+import {ExtentFilter} from './modules/Filter/FilterExtent.js';
+
 // Extent on metropolitan France if not defined in mapBuilder.ini.php
 var originalCenter = [217806.92414447578, 5853470.637803803];
 var originalZoom = 6;
@@ -350,6 +353,16 @@ $(function() {
         }
       });
     }
+
+    // Filter if is active
+    if (!document.getElementById("filterButtonNo").classList.contains("active")) {
+
+      const filterInstance = new ExtentFilter(listTree);
+
+      filterInstance.filter().then(r => {
+        endFilter();
+      });
+    }
   }
 
   mapBuilder.map.on('moveend', onMoveEnd);
@@ -422,6 +435,36 @@ $(function() {
   layerStore = new LayerStore(document.getElementById("layerStoreHolder"));
 
   listTree = layerStore.getTree();
+
+  // Carry filter buttons
+  initFilterButtons();
+
+  /**
+   * Initialize filter buttons.
+   */
+  function initFilterButtons() {
+    document.querySelectorAll('#filterButtons > label').forEach(button => {
+      const filterName = button.children[0].name;
+
+      button.addEventListener("click", async () => {
+        if (filterName === "No") {
+          listTree = layerStore.setAllVisible();
+        } else if (filterName === "Extent") {
+          const filterInstance = new ExtentFilter(listTree);
+          await filterInstance.filter();
+        }
+        layerStore.updateTree(listTree);
+      });
+    });
+  }
+
+  /**
+   * End filter process by updating the tree.
+   */
+  const endFilter = () => {
+    layerStore.updateTree(listTree);
+    listTree = layerStore.getTree();
+  };
 
   /**
    * Get the Layer node from its UUID

--- a/mapBuilder/www/js/modules/Filter/AbstractFilter.js
+++ b/mapBuilder/www/js/modules/Filter/AbstractFilter.js
@@ -1,0 +1,59 @@
+import { LayerTreeFolder } from "../LayerTree/LayerTreeFolder";
+
+export class AbstractFilter {
+
+  /**
+   * @type {LayerTreeFolder} Layer currently filtered.
+   * @private
+   */
+  _currentElement;
+
+  /**
+   * Filter the layer tree.
+   * @param {LayerTreeFolder[]} layerTree - Layer tree to filter.
+   */
+  constructor(layerTree) {
+    this._layerTree = layerTree;
+  }
+
+  /**
+   * Filter the layer tree.
+   */
+  async filter() {
+    for (let i = 0; i < this._layerTree.length; i++) {
+      this._currentElement = this._layerTree[i];
+      this.recFilter(this._layerTree[i]);
+    }
+  }
+
+  /**
+   * Recursive function to filter a layer.
+   * @param {LayerTreeFolder|LayerTreeLayer} layerTreeElement - Layer tree element to filter.
+   */
+  recFilter(layerTreeElement) {
+    throw new Error("Method 'recFilter()' must be implemented.");
+  }
+
+  /**
+   * Set a layer to a decided visibility.
+   * @param {boolean} visibility - Visibility of the layer.
+   */
+  switchAllVisible(visibility) {
+    this.recSwitchAllVisible(this._currentElement, visibility);
+  }
+
+  /**
+   * Recursive function to set a layer to a decided visibility.
+   * @param {LayerTreeFolder|LayerTreeLayer} layerTreeElement - Layer tree element to set invisible.
+   * @param {boolean} visibility - Visibility of the layer.
+   */
+  recSwitchAllVisible(layerTreeElement, visibility) {
+    if (layerTreeElement instanceof LayerTreeFolder) {
+      let children = layerTreeElement.getChildren();
+      for (let i = 0; i < children.length; i++) {
+        this.recSwitchAllVisible(children[i], visibility);
+      }
+    }
+    layerTreeElement.setVisible(visibility);
+  }
+}

--- a/mapBuilder/www/js/modules/Filter/FilterExtent.js
+++ b/mapBuilder/www/js/modules/Filter/FilterExtent.js
@@ -1,0 +1,50 @@
+import { intersects } from 'ol/extent';
+import { transformExtent } from "ol/proj";
+import { AbstractFilter } from "./AbstractFilter";
+
+export class ExtentFilter extends AbstractFilter {
+
+  /**
+   * Filter the layer tree using extent of layers.
+   * @param {[LayerTreeElement]} layerTree - Layer tree to filter.
+   */
+  constructor(layerTree) {
+    super(layerTree);
+  }
+
+  /**
+   * Recursive function to filter a layer.
+   * @param {LayerTreeElement} layerTreeElement - Layer tree element to filter.
+   */
+  recFilter(layerTreeElement) {
+    if (layerTreeElement.getBbox()) {
+      const visibility = this.calculateFilter(layerTreeElement);
+      this.switchAllVisible(visibility);
+      return;
+    }
+    if (!layerTreeElement.hasChildren()) {
+      return;
+    }
+    let children = layerTreeElement.getChildren();
+    for (let i = 0; i < children.length; i++) {
+      this.recFilter(children[i]);
+    }
+  }
+
+  /**
+   * Calculate if the layer should be visible or not
+   * @param {LayerTreeElement} layerTreeElement - Layer tree element to filter
+   * @return {boolean} Visibility of the layer.
+   */
+  calculateFilter(layerTreeElement) {
+    let layerExtent = layerTreeElement.getBbox();
+    let currentExtent = mapBuilder.map.getView().calculateExtent();
+    let currentProjection = mapBuilder.map.getView().getProjection();
+    let mapBuilderExtent = transformExtent(currentExtent, currentProjection, 'EPSG:4326');
+
+    let visible = intersects(layerExtent, mapBuilderExtent);
+    layerTreeElement.setVisible(visible);
+    return visible
+  }
+
+}

--- a/mapBuilder/www/js/modules/Filter/FilterKeywords.js
+++ b/mapBuilder/www/js/modules/Filter/FilterKeywords.js
@@ -1,0 +1,23 @@
+import { AbstractFilter } from "./AbstractFilter";
+
+export class KeywordsFilter extends AbstractFilter {
+
+  /**
+   * Filter the layer tree using keywords of layers.
+   * @param {[LayerTreeElement]} layerTree - Layer tree to filter.
+   */
+  constructor(layerTree, keywords) {
+    super(layerTree);
+    this.keywords = keywords;
+  }
+
+  recFilter(layerTreeElement) {
+    let layerKeywords = layerTreeElement.getKeywords();
+    const visibility = this.calculateFilter(layerKeywords);
+    this.switchAllVisible(visibility);
+  }
+
+  calculateFilter(layerKeywords) {
+    return this.keywords.some(keyword => layerKeywords.includes(keyword));
+  }
+}

--- a/mapBuilder/www/js/modules/Filter/KeywordsManager.js
+++ b/mapBuilder/www/js/modules/Filter/KeywordsManager.js
@@ -1,0 +1,60 @@
+export class KeywordsManager {
+
+  /**
+   * @type {string[]} Keywords.
+   */
+  keywords;
+  /**
+   * @type {string[]} Selected keywords.
+   */
+  selectedKeywords;
+
+  constructor() {
+    this.keywords = [];
+    this.selectedKeywords = [];
+  }
+
+  /**
+   * Add all keywords from a list without duplicates.
+   * @param keywordList
+   */
+  addKeywordFromList(keywordList) {
+    keywordList.forEach(keyword => {
+      if (!this.keywords.includes(keyword)) {
+        this.keywords.push(keyword);
+        this.addKeywordHtml(keyword);
+      }
+    });
+  }
+
+  addKeywordHtml(word) {
+    let div = document.createElement("div");
+
+    div.id = "filterKeyword";
+    div.innerText = word;
+
+    div.addEventListener("click", () => {
+      if (div.className.includes("active")) {
+        div.className = "";
+        this.selectedKeywords.splice(this.selectedKeywords.indexOf(word), 1);
+      } else {
+        div.className = "active";
+        this.selectedKeywords.push(word);
+      }
+
+      const event = new CustomEvent('keywordsUpdated');
+      document.dispatchEvent(event);
+    });
+
+    document.getElementById("filterKeywordsList").append(div);
+  }
+
+  getKeywords() {
+    return this.keywords;
+  }
+
+  getSelectedKeywords() {
+    return this.selectedKeywords;
+  }
+
+}

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeElement.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeElement.js
@@ -25,6 +25,10 @@ export class LayerTreeElement {
    * @type {string} Color of the layer in the CSS sheet.
    */
   #color;
+  /**
+   * @type {boolean} Visibility of the layer for filtering.
+   */
+  #visible;
 
   /**
    * @typedef {Object} Options
@@ -34,6 +38,7 @@ export class LayerTreeElement {
    * @property {string} [#project] Project id.
    * @property {string} [#repository] Repository id.
    * @property {string} [#color] Color of the layer in the CSS sheet.
+   * @property {boolean} [#visible] Visibility of the layer for filtering.
    */
   constructor(options) {
     this.#title = options.title;
@@ -51,6 +56,8 @@ export class LayerTreeElement {
     if (this.#color === undefined) {
       this.#color = this.generateColor();
     }
+
+    this.#visible = true;
   }
 
   /**
@@ -147,5 +154,21 @@ export class LayerTreeElement {
    */
   getColor() {
     return this.#color;
+  }
+
+  /**
+   * Get the visibility of the layer.
+   * @return {boolean} Visibility of the layer.
+   */
+  isVisible() {
+    return this.#visible;
+  }
+
+  /**
+   * Set the visibility of the layer.
+   * @param {boolean} visible Visibility of the layer.
+   */
+  setVisible(visible) {
+    this.#visible = visible;
   }
 }

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeFolder.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeFolder.js
@@ -24,6 +24,10 @@ export class LayerTreeFolder extends LayerTreeElement {
    * @type {boolean} If the folder got a load error.
    */
   #failed;
+  /**
+   * @type {string[]} Keywords of the layer
+   */
+  #keywords = [];
 
   /**
    * @typedef {Object} Options
@@ -188,4 +192,39 @@ export class LayerTreeFolder extends LayerTreeElement {
   setFailed() {
     this.#failed = true;
   }
+
+  /**
+   * Set the keywords of the layer.
+   * @param {string} keywords Keywords of the layer.
+   */
+  setKeywords(keywords) {
+    this.#keywords = keywords;
+  }
+
+  /**
+   * Get the keywords of the layer.
+   * @return {string} Keywords of the layer.
+   */
+  getKeywords() {
+    return this.#keywords;
+  }
+
+  /**
+   * Get the title of the folder which get the "lazy" tag.
+   * @return {string|undefined} Title.
+   */
+  getLazyTitle() {
+    if (this.#lazy !== undefined) {
+      return this.getTitle();
+    }
+    for (let child of this.#children) {
+      if (child instanceof LayerTreeFolder) {
+        let lazyTitle = child.getLazyTitle();
+        if (lazyTitle !== undefined) {
+          return lazyTitle;
+        }
+      }
+    }
+    return undefined;
+}
 }


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->

_Rebase on #56_

Improvement for the `layer-store` from #55 :

* Now we can filter printed layers by their keywords

### Example :

In this example, both projects "Cats" and "Lampadaires" are loaded by clicking on them :

* Cats keywords : infoMapAccessService, Cats, USA, demo, GPS, stats, dataviz
* Lampadaires keywords : infoMapAccessService

[Capture vidéo du 2025-01-27 12-51-19.webm](https://github.com/user-attachments/assets/febe3d95-8952-4b9a-8791-5bb0fef84409)
