### PR TITLE
Indicator of the repository related to the layer selected

### DIFF
--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -368,7 +368,7 @@ ul .layer-store-layer:last-child {
 }
 
 .container-layer-selected .upper-line .title-layer-selected {
-    font-size: 14px;
+    font-size: 16px;
     font-weight: bold;
     cursor: default;
 }
@@ -437,6 +437,16 @@ ul .layer-store-layer:last-child {
 
 .container-layer-selected button.active {
     box-shadow: 0 0 5px 0.5px rgb(0 0 0 / 40%);
+}
+
+.info-layer-selected {
+    display: flex;
+    flex-direction: column;
+}
+
+.repository-layer-selected {
+    font-size: 11px;
+    color: #464646;
 }
 
 custom-slider .slider {

--- a/mapBuilder/www/js/components/LayerSelected.js
+++ b/mapBuilder/www/js/components/LayerSelected.js
@@ -85,7 +85,10 @@ export class LayerSelected extends HTMLElement {
         </div>
         <div class="layer-selected-content">
             <div class="upper-line">
-                <span class="title-layer-selected">${this._element.getLayer().getProperties().title}</span>
+                <div class="info-layer-selected">
+                    <span class="title-layer-selected">${this._element.getLayer().getProperties().title}</span>
+                    <span class="repository-layer-selected">${this._element.getLayer().getProperties().repositoryId}</span>
+                </div>
                 <div class="layer-buttons-div">
                     ${attributeTableShow}
                     <button class="zoomToExtentButton fas fa-search-plus fa-sm"


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Added a span to see from which `repository` a layer comes from

![Capture d’écran du 2025-02-20 13-46-54](https://github.com/user-attachments/assets/b7ed7983-f343-40a1-b568-1e3b3387a3e6)
