### PR TITLE
Updated structure, Logo for projects and fix bugs

### DIFF
--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -442,11 +442,14 @@ ul .layer-store-layer:last-child {
 .info-layer-selected {
     display: flex;
     flex-direction: column;
+    max-width: 140px;
+    overflow: hidden;
 }
 
 .repository-layer-selected {
     font-size: 11px;
     color: #464646;
+    white-space: nowrap;
 }
 
 .layer-store-folder.project {

--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -449,6 +449,11 @@ ul .layer-store-layer:last-child {
     color: #464646;
 }
 
+.layer-store-folder.project {
+    content: url("./svg/project.svg");
+    width: 30px;
+}
+
 custom-slider .slider {
     width: 180px;
     border-radius: 3px;

--- a/mapBuilder/www/css/svg/project.svg
+++ b/mapBuilder/www/css/svg/project.svg
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="uEA37-globe-alt.svg"
+   id="svg4460"
+   height="100"
+   width="100"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:current-layer="svg4460"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="-8"
+     inkscape:cy="58.351341"
+     inkscape:cx="124.42877"
+     inkscape:zoom="3.805"
+     showgrid="false"
+     id="namedview11"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <defs
+     id="defs4462" />
+  <metadata
+     id="metadata4465">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 47.5 5.2695312 C 42.400861 6.3354777 37.544204 10.629358 33.695312 17.619141 C 32.548003 19.702716 31.509261 22.015173 30.59375 24.507812 C 35.75554 25.831631 41.46707 26.656797 47.5 26.835938 L 47.5 5.2695312 z M 52.5 5.2695312 L 52.5 26.835938 C 58.53293 26.656799 64.24446 25.831632 69.40625 24.507812 C 68.490739 22.015173 67.451998 19.702716 66.304688 17.619141 C 62.455795 10.629358 57.599139 6.3354777 52.5 5.2695312 z M 34.587891 7.7011719 C 27.876229 10.142099 21.914624 14.134277 17.132812 19.244141 C 17.296142 19.33709 17.452463 19.431658 17.619141 19.523438 C 20.054636 20.864531 22.799202 22.058431 25.785156 23.078125 C 26.809248 20.256587 27.987643 17.616587 29.314453 15.207031 C 30.865341 12.39054 32.633845 9.8565742 34.587891 7.7011719 z M 65.412109 7.7011719 C 67.366155 9.8565742 69.134659 12.39054 70.685547 15.207031 C 72.012404 17.616672 73.190633 20.257594 74.212891 23.080078 C 77.199767 22.060208 79.944718 20.864887 82.380859 19.523438 C 82.547537 19.431656 82.703858 19.337091 82.867188 19.244141 C 78.085376 14.134277 72.123771 10.142099 65.412109 7.7011719 z M 13.884766 23.134766 C 8.7706501 30.00525 5.5696696 38.387702 5.0722656 47.5 L 21.378906 47.5 C 21.572141 40.474778 22.576088 33.829903 24.25 27.847656 C 20.981775 26.734921 17.947825 25.413502 15.207031 23.904297 C 14.755883 23.655874 14.320222 23.394762 13.884766 23.134766 z M 86.115234 23.134766 C 85.679778 23.394762 85.244117 23.655874 84.792969 23.904297 C 82.050255 25.414559 79.013105 26.736636 75.742188 27.849609 C 77.411117 33.831967 78.410594 40.47683 78.603516 47.5 L 94.927734 47.5 C 94.430331 38.387702 91.22935 30.00525 86.115234 23.134766 z M 29.056641 29.283203 C 27.528979 34.780487 26.577213 40.953139 26.382812 47.5 L 47.5 47.5 L 47.5 31.824219 C 40.944204 31.644021 34.72159 30.758556 29.056641 29.283203 z M 70.943359 29.283203 C 65.278701 30.757938 59.055256 31.6421 52.5 31.822266 L 52.5 47.5 L 73.617188 47.5 C 73.422788 40.953139 72.471021 34.780487 70.943359 29.283203 z M 5.0722656 52.5 C 5.5696696 61.612298 8.7706501 69.99475 13.884766 76.865234 C 14.320222 76.605238 14.755883 76.344126 15.207031 76.095703 C 17.947676 74.58658 20.982846 73.264801 24.25 72.150391 C 22.576391 66.168613 21.572121 59.524516 21.378906 52.5 L 5.0722656 52.5 z M 26.382812 52.5 C 26.577123 59.043807 27.528276 65.213633 29.054688 70.708984 C 34.719732 69.230102 40.942429 68.340527 47.5 68.160156 L 47.5 52.5 L 26.382812 52.5 z M 52.5 52.5 L 52.5 68.160156 C 59.057571 68.340527 65.280267 69.230102 70.945312 70.708984 C 72.471724 65.213633 73.422877 59.043807 73.617188 52.5 L 52.5 52.5 z M 78.605469 52.5 C 78.412513 59.522553 77.413284 66.166589 75.744141 72.148438 C 79.01354 73.263262 82.050679 74.585674 84.792969 76.095703 C 85.244117 76.344126 85.679778 76.605238 86.115234 76.865234 C 91.22935 69.99475 94.430331 61.612298 94.927734 52.5 L 78.605469 52.5 z M 47.5 73.164062 C 41.46707 73.343201 35.75554 74.168368 30.59375 75.492188 C 31.509261 77.984827 32.548002 80.297284 33.695312 82.380859 C 37.544205 89.370642 42.400861 93.664522 47.5 94.730469 L 47.5 73.164062 z M 52.5 73.164062 L 52.5 94.730469 C 57.599139 93.664522 62.455796 89.370642 66.304688 82.380859 C 67.451998 80.297284 68.490739 77.984826 69.40625 75.492188 C 64.24446 74.168368 58.53293 73.343202 52.5 73.164062 z M 74.212891 76.919922 C 73.190414 79.742395 72.012425 82.383289 70.685547 84.792969 C 69.134659 87.60946 67.366155 90.143426 65.412109 92.298828 C 72.123771 89.857901 78.085375 85.865723 82.867188 80.755859 C 82.703859 80.66291 82.547537 80.568342 82.380859 80.476562 C 79.944718 79.135114 77.199767 77.939792 74.212891 76.919922 z M 25.785156 76.921875 C 22.799202 77.941569 20.054636 79.135469 17.619141 80.476562 C 17.452463 80.568344 17.296142 80.662909 17.132812 80.755859 C 21.914624 85.865723 27.876229 89.857901 34.587891 92.298828 C 32.633845 90.143426 30.865341 87.60946 29.314453 84.792969 C 27.987643 82.383413 26.809248 79.743413 25.785156 76.921875 z "
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:rgb(0, 0, 0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:188.976;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     id="path862" />
+</svg>

--- a/mapBuilder/www/js/components/LayerStore.js
+++ b/mapBuilder/www/js/components/LayerStore.js
@@ -60,7 +60,7 @@ export class LayerStore extends HTMLElement {
                 icoSpan = "fa-window-close";
                 tagLazy = "failed";
             } else {
-                icoSpan = element.isOpened() ? "fa-folder-open" : "fa-folder";
+                icoSpan = "project";
             }
         }
 

--- a/mapBuilder/www/js/components/LayerStore.js
+++ b/mapBuilder/www/js/components/LayerStore.js
@@ -2,6 +2,7 @@ import {html, render, nothing} from 'lit-html';
 import {LayerTreeFolder} from "../modules/LayerTree/LayerTreeFolder";
 import {WMSCapabilities} from "ol/format";
 import {LayerTreeLayer} from "../modules/LayerTree/LayerTreeLayer";
+import {LayerTreeProject} from "../modules/LayerTree/LayerTreeProject";
 
 /**
  * Class representing the layer store.
@@ -44,22 +45,23 @@ export class LayerStore extends HTMLElement {
      */
     folderTemplate(element) {
     //Check if the folder will have to load children from a project.
-        let tagLazy = element.isLazy() ? "lazy" : "";
+        let icoSpan = element.isOpened() ? "fa-folder-open" : "fa-folder";
+        let tagLazy = "";
 
-        let icoSpan;
+        if (element instanceof LayerTreeProject) {
+            tagLazy = element.isLazy() ? "lazy" : "";
 
-        //Check if the folder is loading, opened or closed.
-        if (element.isLoading()) {
-            icoSpan = "fa-spinner fa-pulse";
-        } else {
-            icoSpan = element.isOpened() ? "fa-folder-open" : "fa-folder";
-        }
-
-        //Check if the folder is failed to load children.
-        //It occurs when the project can't be loaded.
-        if (element.isFailed()) {
-            icoSpan = "fa-window-close";
-            tagLazy = "failed";
+            //Check if the folder is loading, opened or closed.
+            if (element.isLoading()) {
+                icoSpan = "fa-spinner fa-pulse";
+            } else if (element.isFailed()) {
+                //Check if the folder is failed to load children.
+                //It occurs when the project can't be loaded.
+                icoSpan = "fa-window-close";
+                tagLazy = "failed";
+            } else {
+                icoSpan = element.isOpened() ? "fa-folder-open" : "fa-folder";
+            }
         }
 
         //Template of a folder.
@@ -162,35 +164,49 @@ export class LayerStore extends HTMLElement {
      * Action when a folder is clicked.
      * It can open or close the folder.
      * It can decide to load the project and put children in the folder.
-     * @param {LayerTreeFolder} element The folder clicked.
+     * @param {LayerTreeFolder|LayerTreeProject} element The folder clicked.
      * @param {Event} e Event occurring.
      */
     async action(element, e) {
-        if (element.isLazy()) {
+        const handleLazyLoading = async () => {
             element.setLoading(true);
             this.render();
-            //Prevent from multiple request
+
+            // Prevent multiple requests
             element.setLazy(false);
             e.target.closest('.lazy').children[0].className = "layer-store-folder fas fa-spinner fa-pulse";
-            //After loaded
-            let child = await this.loadTree(element);
-            element.setLazy(false);
+
+            // Load folder content
+            let children = await this.loadTree(element);
             element.setLoading(false);
-            if (child.length > 0) {
-                child.forEach((el) => {
-                    el.repository = element.getRepository();
-                    el.project = element.getProject();
-                });
-                element.createChildren(child);
+
+            if (children.length > 0) {
+                updateChildrenAttributes(children, element);
+                element.createChildren(children);
                 element.changeStatusFolder();
             } else {
                 element.setFailed();
             }
+        };
+
+        const updateChildrenAttributes = (children, element) => {
+            children.forEach((child) => {
+                child.repository = element.getRepository();
+                child.project = element.getProject();
+            });
+        };
+
+        if (element instanceof LayerTreeProject) {
+            if (element.isLazy()) {
+                await handleLazyLoading();
+            } else {
+                element.changeStatusFolder();
+            }
         } else {
             element.changeStatusFolder();
         }
-        this.render();
 
+        this.render();
     };
 
     /**

--- a/mapBuilder/www/js/main.js
+++ b/mapBuilder/www/js/main.js
@@ -543,6 +543,10 @@ $(function() {
         document.getElementById('legend-content').innerHTML = legendsDiv;
     }
 
+    document.addEventListener('layerSelectedChanges', function () {
+        loadLegend();
+    });
+    
     // Open/Close dock behaviour
     $('#dock-close > button').on("click", function(){
         $('#mapmenu .dock').removeClass('active');

--- a/mapBuilder/www/js/main.js
+++ b/mapBuilder/www/js/main.js
@@ -464,6 +464,7 @@ $(function() {
                     serverType: 'qgis'
                 })
             });
+            newLayer.setProperties({"projectName": node.getProjectName()});
 
             // Set min/max resolution if min/max scale are defined in getCapabilities
             if (node.getMinScale()) {

--- a/mapBuilder/www/js/modules/LayerSelection/LayerSelection.js
+++ b/mapBuilder/www/js/modules/LayerSelection/LayerSelection.js
@@ -103,6 +103,7 @@ export function changeList(uid, direction) {
 /**
  * Change the order of the layer with the one above.
  * @param {string} uid layer's uid
+ * @param {HTMLElement} element layer to switch
  */
 function changeOrderUp(uid, element) {
     layerArray.changeOrder(uid, "up");
@@ -115,6 +116,7 @@ function changeOrderUp(uid, element) {
 /**
  * Change the order of the layer with the one below.
  * @param {string} uid layer's uid
+ * @param {HTMLElement} element layer to switch
  */
 function changeOrderDown(uid, element) {
     layerArray.changeOrder(uid, "down");

--- a/mapBuilder/www/js/modules/LayerSelection/LayerSelection.js
+++ b/mapBuilder/www/js/modules/LayerSelection/LayerSelection.js
@@ -97,6 +97,7 @@ export function changeList(uid, direction) {
     } else {
         changeOrderDown(uid, element);
     }
+    document.dispatchEvent(new CustomEvent('layerSelectedChanges'));
 }
 
 /**

--- a/mapBuilder/www/js/modules/LayerSelection/LayerSelection.js
+++ b/mapBuilder/www/js/modules/LayerSelection/LayerSelection.js
@@ -43,15 +43,16 @@ export function addElementToLayerArray(value, color) {
         e.preventDefault();
         const data = e.dataTransfer.getData('text/plain');
         const draggedElement = document.getElementById(data);
+        const draggedElementId = draggedElement.dataset.olUid;
 
         let index = getIndexOfDrop(dropZone, e.clientY);
 
-        while (layerArray.getIndexOf(draggedElement.id) !== index) {
-            let currentIndex = layerArray.getIndexOf(draggedElement.id);
+        while (layerArray.getIndexOf(draggedElementId) !== index) {
+            let currentIndex = layerArray.getIndexOf(draggedElementId);
             if (currentIndex > index) {
-                changeList(draggedElement.id, "up");
+                changeList(draggedElementId, "up");
             } else {
-                changeList(draggedElement.id, "down");
+                changeList(draggedElementId, "down");
             }
         }
     });
@@ -90,10 +91,11 @@ export function getLayerSelectionArray() {
  * @param {string} direction Which direction to go : 'up' or 'down'.
  */
 export function changeList(uid, direction) {
+    let element = document.getElementById(`layer_${uid}`);
     if (direction === "up") {
-        changeOrderUp(uid);
+        changeOrderUp(uid, element);
     } else {
-        changeOrderDown(uid);
+        changeOrderDown(uid, element);
     }
 }
 
@@ -101,9 +103,8 @@ export function changeList(uid, direction) {
  * Change the order of the layer with the one above.
  * @param {string} uid layer's uid
  */
-function changeOrderUp(uid) {
+function changeOrderUp(uid, element) {
     layerArray.changeOrder(uid, "up");
-    let element = document.getElementById(`${uid}`);
     switchVisualLayers(
         element,
         element.previousElementSibling
@@ -114,9 +115,8 @@ function changeOrderUp(uid) {
  * Change the order of the layer with the one below.
  * @param {string} uid layer's uid
  */
-function changeOrderDown(uid) {
+function changeOrderDown(uid, element) {
     layerArray.changeOrder(uid, "down");
-    let element = document.getElementById(`${uid}`);
     switchVisualLayers(
         element,
         element.nextElementSibling

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeElement.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeElement.js
@@ -4,6 +4,7 @@
  * @property {Array} _bbox Bbox.
  * @property {boolean} _popup Popup.
  * @property {string} _project Project id.
+ * @property {string} _projectName Project name.
  * @property {string} _repository Repository id.
  * @property {string} _color Color of the layer in the CSS sheet.
  */
@@ -20,6 +21,8 @@ export class LayerTreeElement {
         this._popup = options.popup !== undefined ? options.popup : undefined;
 
         this._project = options.project !== undefined ? options.project : undefined;
+
+        this._projectName = options.projectName !== undefined ? options.projectName : undefined;
 
         this._repository = options.repository !== undefined ? options.repository : undefined;
 
@@ -109,6 +112,14 @@ export class LayerTreeElement {
      */
     getProject() {
         return this._project;
+    }
+
+    /**
+     * Get the project name.
+     * @returns {string} Project name.
+     */
+    getProjectName() {
+        return this._projectName;
     }
 
     /**

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeFactory.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeFactory.js
@@ -1,0 +1,54 @@
+import {LayerTreeLayer} from "./LayerTreeLayer";
+import {LayerTreeFolder} from "./LayerTreeFolder";
+import {LayerTreeProject} from "./LayerTreeProject";
+
+/**
+ * A factory class for creating different types of Layer Tree elements such as layers, folders, and projects.
+ * We need this class as the LayerTreeProject create some LayerTreeFolder ones. So in order to prevent errors
+ * like "can't access lexical declaration 'LayerTreeFolder' before initialization", we need to lazy load this
+ * class.
+ */
+export class LayerTreeFactory {
+  static createLayerTreeElement(value, layerTreeFolder) {
+    value.color = layerTreeFolder.getColor();
+
+    if (value.hasOwnProperty("style")) {
+      value.repository = layerTreeFolder.getRepository();
+      value.project = layerTreeFolder.getProject();
+
+      return new LayerTreeLayer({
+        bbox: value.bbox,
+        attributeTable: value.hasAttributeTable,
+        name: value.name,
+        popup: value.popup,
+        style: value.style,
+        title: value.title,
+        tooltip: value.tooltip,
+        project: value.project,
+        repository: value.repository,
+        color: value.color,
+      });
+    } else if (value.lazy) {
+      return new LayerTreeProject({
+        title: value.title,
+        children: value.children,
+        lazy: value.lazy,
+        project: value.project,
+        repository: value.repository,
+        bbox: value.bbox,
+        popup: value.popup,
+        color: value.color
+      });
+    } else {
+      return new LayerTreeFolder({
+        title: value.title,
+        children: value.children,
+        project: value.project,
+        repository: value.repository,
+        bbox: value.bbox,
+        popup: value.popup,
+        color: value.color
+      });
+    }
+  }
+}

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeFactory.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeFactory.js
@@ -9,48 +9,48 @@ import {LayerTreeProject} from "./LayerTreeProject";
  * class.
  */
 export class LayerTreeFactory {
-  static createLayerTreeElement(value, layerTreeFolder) {
-    value.color = layerTreeFolder.getColor();
+    static createLayerTreeElement(value, layerTreeFolder) {
+        value.color = layerTreeFolder.getColor();
 
-    if (value.hasOwnProperty("style")) {
-      value.repository = layerTreeFolder.getRepository();
-      value.project = layerTreeFolder.getProject();
+        if (value.hasOwnProperty("style")) {
+            value.repository = layerTreeFolder.getRepository();
+            value.project = layerTreeFolder.getProject();
 
-      return new LayerTreeLayer({
-        bbox: value.bbox,
-        attributeTable: value.hasAttributeTable,
-        name: value.name,
-        popup: value.popup,
-        style: value.style,
-        title: value.title,
-        tooltip: value.tooltip,
-        project: value.project,
-        projectName: layerTreeFolder.getProjectName(),
-        repository: value.repository,
-        color: value.color,
-      });
-    } else if (value.lazy) {
-      return new LayerTreeProject({
-        title: value.title,
-        children: value.children,
-        lazy: value.lazy,
-        project: value.project,
-        repository: value.repository,
-        bbox: value.bbox,
-        popup: value.popup,
-        color: value.color
-      });
-    } else {
-      return new LayerTreeFolder({
-        title: value.title,
-        children: value.children,
-        project: value.project,
-        projectName: layerTreeFolder.getProjectName(),
-        repository: value.repository,
-        bbox: value.bbox,
-        popup: value.popup,
-        color: value.color
-      });
+            return new LayerTreeLayer({
+                bbox: value.bbox,
+                attributeTable: value.hasAttributeTable,
+                name: value.name,
+                popup: value.popup,
+                style: value.style,
+                title: value.title,
+                tooltip: value.tooltip,
+                project: value.project,
+                projectName: layerTreeFolder.getProjectName(),
+                repository: value.repository,
+                color: value.color,
+            });
+        } else if (value.lazy) {
+            return new LayerTreeProject({
+                title: value.title,
+                children: value.children,
+                lazy: value.lazy,
+                project: value.project,
+                repository: value.repository,
+                bbox: value.bbox,
+                popup: value.popup,
+                color: value.color
+            });
+        } else {
+            return new LayerTreeFolder({
+                title: value.title,
+                children: value.children,
+                project: value.project,
+                projectName: layerTreeFolder.getProjectName(),
+                repository: value.repository,
+                bbox: value.bbox,
+                popup: value.popup,
+                color: value.color
+            });
+        }
     }
-  }
 }

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeFactory.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeFactory.js
@@ -25,6 +25,7 @@ export class LayerTreeFactory {
         title: value.title,
         tooltip: value.tooltip,
         project: value.project,
+        projectName: layerTreeFolder.getProjectName(),
         repository: value.repository,
         color: value.color,
       });
@@ -44,6 +45,7 @@ export class LayerTreeFactory {
         title: value.title,
         children: value.children,
         project: value.project,
+        projectName: layerTreeFolder.getProjectName(),
         repository: value.repository,
         bbox: value.bbox,
         popup: value.popup,

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeFolder.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeFolder.js
@@ -1,4 +1,3 @@
-import {LayerTreeLayer} from "./LayerTreeLayer";
 import {LayerTreeElement} from "./LayerTreeElement";
 
 /**
@@ -34,15 +33,9 @@ export class LayerTreeFolder extends LayerTreeElement {
 
         this._opened = false;
 
-        this._lazy = options.lazy !== undefined ? options.lazy : undefined;
-
-        this._loading = false;
-
         if (this._children.length > 0) {
             this.createChildren();
         }
-
-        this._failed = false;
     }
 
     /**
@@ -51,6 +44,7 @@ export class LayerTreeFolder extends LayerTreeElement {
      * This function can be used when children are loaded from
      * a project, so they can be passed to the "children" param.
      * @param {[]} children Children of the folder.
+     * TODO : update doc
      */
     createChildren(children = undefined) {
         let list = [];
@@ -58,35 +52,9 @@ export class LayerTreeFolder extends LayerTreeElement {
         let listChild = children !== undefined ? children : this._children;
 
         listChild.forEach((value) => {
-            value.color = this.getColor();
-            if (value.hasOwnProperty("style")) {
-                value.repository = this.getRepository();
-                value.project = this.getProject();
+            const {LayerTreeFactory} = require('./LayerTreeFactory');
 
-                list.push(new LayerTreeLayer({
-                    bbox: value.bbox,
-                    attributeTable: value.hasAttributeTable,
-                    name: value.name,
-                    popup: value.popup,
-                    style: value.style,
-                    title: value.title,
-                    tooltip: value.tooltip,
-                    project: value.project,
-                    repository: value.repository,
-                    color: value.color,
-                }));
-            } else {
-                list.push(new LayerTreeFolder({
-                    title: value.title,
-                    children: value.children,
-                    lazy: value.lazy,
-                    project: value.project,
-                    repository: value.repository,
-                    bbox: value.bbox,
-                    popup: value.popup,
-                    color: value.color
-                }));
-            }
+            list.push(LayerTreeFactory.createLayerTreeElement(value, this));
         });
         this._children = list;
     }
@@ -97,38 +65,6 @@ export class LayerTreeFolder extends LayerTreeElement {
      */
     changeStatusFolder() {
         this._opened = !this._opened;
-    }
-
-    /**
-     * Get the status of the folder.
-     * @returns {boolean} Status of the folder.
-     */
-    isLazy() {
-        return !!this._lazy;
-    }
-
-    /**
-     * Set the lazy status of the folder.
-     * @param {boolean} value New lazy status.
-     */
-    setLazy(value) {
-        this._lazy = value;
-    }
-
-    /**
-     * Get the loading state of the folder.
-     * @returns {boolean} Loading state.
-     */
-    isLoading() {
-        return this._loading;
-    }
-
-    /**
-     * Set the loading state of the folder.
-     * @param {boolean} value New loading state.
-     */
-    setLoading(value) {
-        this._loading = value;
     }
 
     /**
@@ -153,20 +89,5 @@ export class LayerTreeFolder extends LayerTreeElement {
      */
     isOpened() {
         return this._opened;
-    }
-
-    /**
-     * Get the failed state of the folder.
-     * @returns {boolean} Failed state.
-     */
-    isFailed() {
-        return this._failed;
-    }
-
-    /**
-     * Set the failed state of the folder to "true".
-     */
-    setFailed() {
-        this._failed = true;
     }
 }

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeFolder.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeFolder.js
@@ -19,6 +19,7 @@ export class LayerTreeFolder extends LayerTreeElement {
             popup: options.popup,
             bbox: options.bbox,
             project: options.project,
+            projectName: options.projectName,
             repository: options.repository,
             color: options.color
         });

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeFolder.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeFolder.js
@@ -2,11 +2,8 @@ import {LayerTreeElement} from "./LayerTreeElement";
 
 /**
  * Class representing a folder in a Layer Tree.
- @property {Array} _children Queue length.
- @property {boolean} _opened If the folder is opened or not for the visual part.
- @property {boolean} _lazy If the folder will have to load children from a project.
- @property {boolean} _loading Loading state of the folder.
- @property {boolean} _failed If the folder got a load error.
+ * @property {Array} _children Queue length.
+ * @property {boolean} _opened If the folder is opened or not for the visual part.
  */
 export class LayerTreeFolder extends LayerTreeElement {
     /**
@@ -45,7 +42,6 @@ export class LayerTreeFolder extends LayerTreeElement {
      * This function can be used when children are loaded from
      * a project, so they can be passed to the "children" param.
      * @param {[]} children Children of the folder.
-     * TODO : update doc
      */
     createChildren(children = undefined) {
         let list = [];

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeLayer.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeLayer.js
@@ -22,6 +22,7 @@ export class LayerTreeLayer extends LayerTreeElement {
             popup: options.popup,
             bbox: options.bbox,
             project: options.project,
+            projectName: options.projectName,
             repository: options.repository,
             color: options.color
         });

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
@@ -1,69 +1,75 @@
 import {LayerTreeFolder} from "./LayerTreeFolder";
 
+/**
+ *  Class representing a folder that represents a project.
+ *  @property {boolean} _lazy If the folder will have to load children from a project.
+ *  @property {boolean} _loading Loading state of the folder.
+ *  @property {boolean} _failed If the folder got a load error.
+ */
 export class LayerTreeProject extends LayerTreeFolder {
 
-  constructor(options) {
-    super({
-      title: options.title,
-      popup: options.popup,
-      bbox: options.bbox,
-      project: options.project,
-      projectName: options.title,
-      repository: options.repository,
-      color: options.color
-    });
+    constructor(options) {
+        super({
+            title: options.title,
+            popup: options.popup,
+            bbox: options.bbox,
+            project: options.project,
+            projectName: options.title,
+            repository: options.repository,
+            color: options.color
+        });
 
-    this._lazy = options.lazy !== undefined ? options.lazy : undefined;
+        this._lazy = options.lazy !== undefined ? options.lazy : undefined;
 
-    this._loading = false;
+        this._loading = false;
 
-    this._failed = false;
-  }
+        this._failed = false;
+    }
 
-  /**
-   * Get the status of the folder.
-   * @returns {boolean} Status of the folder.
-   */
-  isLazy() {
-    return !!this._lazy;
-  }
+    /**
+     * Get the status of the folder.
+     * @returns {boolean} Status of the folder.
+     */
+    isLazy() {
+        return !!this._lazy;
+    }
 
-  /**
-   * Set the lazy status of the folder.
-   * @param {boolean} value New lazy status.
-   */
-  setLazy(value) {
-    this._lazy = value;
-  }
+    /**
+     * Set the lazy status of the folder.
+     * @param {boolean} value New lazy status.
+     */
+    setLazy(value) {
+        this._lazy = value;
+    }
 
-  /**
-   * Get the loading state of the folder.
-   * @returns {boolean} Loading state.
-   */
-  isLoading() {
-    return this._loading;
-  }
+    /**
+     * Get the loading state of the folder.
+     * @returns {boolean} Loading state.
+     */
+    isLoading() {
+        return this._loading;
+    }
 
-  /**
-   * Set the loading state of the folder.
-   * @param {boolean} value New loading state.
-   */
-  setLoading(value) {
-    this._loading = value;
-  }
+    /**
+     * Set the loading state of the folder.
+     * @param {boolean} value New loading state.
+     */
+    setLoading(value) {
+        this._loading = value;
+    }
 
-  /**
-   * Get the failed state of the folder.
-   * @returns {boolean} Failed state.
-   */
-  isFailed() {
-    return this._failed;
-  }
+    /**
+     * Get the failed state of the folder.
+     * @returns {boolean} Failed state.
+     */
+    isFailed() {
+        return this._failed;
+    }
 
-  /**
-   * Set the failed state of the folder to "true".
-   */
-  setFailed() {
-    this._failed = true;
-  }
+    /**
+     * Set the failed state of the folder to "true".
+     */
+    setFailed() {
+        this._failed = true;
+    }
 }

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
@@ -8,6 +8,7 @@ export class LayerTreeProject extends LayerTreeFolder {
       popup: options.popup,
       bbox: options.bbox,
       project: options.project,
+      projectName: options.title,
       repository: options.repository,
       color: options.color
     });

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
@@ -1,0 +1,68 @@
+import {LayerTreeFolder} from "./LayerTreeFolder";
+
+export class LayerTreeProject extends LayerTreeFolder {
+
+  constructor(options) {
+    super({
+      title: options.title,
+      popup: options.popup,
+      bbox: options.bbox,
+      project: options.project,
+      repository: options.repository,
+      color: options.color
+    });
+
+    this._lazy = options.lazy !== undefined ? options.lazy : undefined;
+
+    this._loading = false;
+
+    this._failed = false;
+  }
+
+  /**
+   * Get the status of the folder.
+   * @returns {boolean} Status of the folder.
+   */
+  isLazy() {
+    return !!this._lazy;
+  }
+
+  /**
+   * Set the lazy status of the folder.
+   * @param {boolean} value New lazy status.
+   */
+  setLazy(value) {
+    this._lazy = value;
+  }
+
+  /**
+   * Get the loading state of the folder.
+   * @returns {boolean} Loading state.
+   */
+  isLoading() {
+    return this._loading;
+  }
+
+  /**
+   * Set the loading state of the folder.
+   * @param {boolean} value New loading state.
+   */
+  setLoading(value) {
+    this._loading = value;
+  }
+
+  /**
+   * Get the failed state of the folder.
+   * @returns {boolean} Failed state.
+   */
+  isFailed() {
+    return this._failed;
+  }
+
+  /**
+   * Set the failed state of the folder to "true".
+   */
+  setFailed() {
+    this._failed = true;
+  }
+}


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->

## Changes

* **Fixed** the legend, it wasn't updating itself when changing selected layers order with `buttons` or `drag'n drop`
* **Replaced** the `repositoryId` under layers name by the `projectName` _(from #72)_. In case of long name, the `projectName` is written with its first characters. Mouse on it will display the full name by scrolling automatically.
* **Added** a logo on projects folders.
* **Updated** the structure

## Project name : 

https://github.com/user-attachments/assets/e5bea9e3-fbfb-498c-9dcc-a622cf6e94d2

## Logo for projects : 

<img src="https://github.com/user-attachments/assets/df1e0e13-8c49-405c-a4f0-7437969e4236" width="450"/>

## Structure : 

### Before 

Previously, the `LayerStore` had **2** different type of node : 
* **LayerTreeFolder**
* **LayerTreeLayer**

<img src="https://github.com/user-attachments/assets/6384599a-9e05-4af2-ba49-ea419fdfbb94" width="450"/>

<img src="https://github.com/user-attachments/assets/def6b546-f713-4c54-9dae-a4c02e6c2f22" width="500"/>

### After

Now, the `LayerStore` has 3 different type of node : 
* **LayerTreeFolder**
* **LayerTreeProject**
* **LayerTreeFolder**

<img src="https://github.com/user-attachments/assets/68c7054d-bae8-461d-9b19-4ba7c7b461a5" width="450"/>

<img src="https://github.com/user-attachments/assets/2f2c903d-42ce-49de-b860-22a6cb39fd65" width="500"/>



