### PR TITLE
Fix on id taken by attribute table

### DIFF
--- a/mapBuilder/www/js/components/LayerSelected.js
+++ b/mapBuilder/www/js/components/LayerSelected.js
@@ -268,7 +268,7 @@ export class LayerSelected extends HTMLElement {
     actionDisplayDataButton(e, element) {
         document.getElementById("attribute-btn").classList.add("active");
 
-        var idLayer = e.target.closest(".container-layer-selected").id;
+        var idLayer = e.target.closest(".container-layer-selected").dataset.olUid;
         var layer;
         var layerElement;
 


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->

* **Fix** from how `layerId` is placed on a selected layer. _(original commit : [0341d50](https://github.com/3liz/lizmap-mapbuilder-module/commit/0341d50dae45c655c57cf1d8ab812372856be013))_
* Now we can open attribute tables.