### PR TITLE
Add keywords filter

### DIFF
--- a/mapBuilder/locales/en_US/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/en_US/dictionary.UTF-8.properties
@@ -12,3 +12,5 @@ layer.deleted=Layer deleted.
 error.api.inkmap=API key missing.
 filter.button.no=No filter
 filter.button.extent=Filter by extent
+filter.button.keywords=Filter by keywords
+filter.keywords.list=Show keywords list

--- a/mapBuilder/locales/en_US/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/en_US/dictionary.UTF-8.properties
@@ -14,3 +14,6 @@ filter.button.no=No filter
 filter.button.extent=Filter by extent
 filter.button.keywords=Filter by keywords
 filter.keywords.list=Show keywords list
+filter.keywords.radio.union=Union
+filter.keywords.radio.intersect=Intersect
+filter.keywords.search.placeholder=Find keywords...

--- a/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
@@ -12,3 +12,5 @@ layer.deleted=Couche supprimée.
 error.api.inkmap=Clé API manquante.
 filter.button.no=Pas de filtre
 filter.button.extent=Filtrer par emprise
+filter.button.keywords=Filtrer par mots-clés
+filter.keywords.list=Afficher la liste des mots-clés

--- a/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/fr_FR/dictionary.UTF-8.properties
@@ -14,3 +14,6 @@ filter.button.no=Pas de filtre
 filter.button.extent=Filtrer par emprise
 filter.button.keywords=Filtrer par mots-clés
 filter.keywords.list=Afficher la liste des mots-clés
+filter.keywords.radio.union=Union
+filter.keywords.radio.intersect=Intersection
+filter.keywords.search.placeholder=Trouver des mots-clés...

--- a/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
@@ -12,3 +12,5 @@ layer.deleted=Camada eliminada
 error.api.inkmap=Chave de API em falta.
 filter.button.no=Sem filtro
 filter.button.extent=Filtrar por extensão
+filter.button.keywords=Filtrar por palavras-chave
+filter.keywords.list=Mostrar lista de palavras-chave

--- a/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
+++ b/mapBuilder/locales/pt_PT/dictionary.UTF-8.properties
@@ -14,3 +14,6 @@ filter.button.no=Sem filtro
 filter.button.extent=Filtrar por extensão
 filter.button.keywords=Filtrar por palavras-chave
 filter.keywords.list=Mostrar lista de palavras-chave
+filter.keywords.radio.union=União
+filter.keywords.radio.intersect=Intersecção
+filter.keywords.search.placeholder=Encontrar palavras-chave...

--- a/mapBuilder/templates/main.tpl
+++ b/mapBuilder/templates/main.tpl
@@ -109,6 +109,16 @@
           <label class="btn btn-secondary btn-sm" id="filterButtonExtent">
             <input type="radio" name="Extent" autocomplete="off"> {@mapBuilder~dictionary.filter.button.extent@}
           </label>
+          <label class="btn btn-secondary btn-sm" id="filterButtonKeywords">
+            <input type="radio" name="Keywords" autocomplete="off"> {@mapBuilder~dictionary.filter.button.keywords@}
+          </label>
+        </div>
+        <div id="filterKeywordsHandler">
+          <button id="filterKeywordsListButton" type="button" class="btn btn-sm btn-info dropdown-toggle">
+            {@mapBuilder~dictionary.filter.keywords.list@}
+          </button>
+          <div id="filterKeywordsList" class="">
+          </div>
         </div>
       </div>
       <div id="base-layer">

--- a/mapBuilder/templates/main.tpl
+++ b/mapBuilder/templates/main.tpl
@@ -118,6 +118,20 @@
             {@mapBuilder~dictionary.filter.keywords.list@}
           </button>
           <div id="filterKeywordsList" class="">
+            <div id="filterKeywordsListUtilsBar">
+              <div class="btn-group btn-group-toggle" data-toggle="buttons">
+                <label id="keywordsUnionButton" class="btn btn-outline-secondary btn-sm active">
+                  <input type="radio" name="options" checked> {@mapBuilder~dictionary.filter.keywords.radio.union@}
+                </label>
+                <label id="keywordsIntersectButton" class="btn btn-outline-secondary btn-sm">
+                  <input type="radio" name="options"> {@mapBuilder~dictionary.filter.keywords.radio.intersect@}
+                </label>
+              </div>
+              <div class="input-group input-group-sm ml-3 mr-2">
+                <input type="text" class="form-control" placeholder="{@mapBuilder~dictionary.filter.keywords.search.placeholder@}" aria-label="Username">
+              </div>
+            </div>
+            <div id="filterKeywordsListWords"></div>
           </div>
         </div>
       </div>

--- a/mapBuilder/templates/main.tpl
+++ b/mapBuilder/templates/main.tpl
@@ -102,7 +102,7 @@
         <span id="layers-loading"></span>
       </div>
       <div id="layer-store-holder">
-        <button id="filterButtonNo" type="button" class="btn btn-secondary btn-sm">{@mapBuilder~dictionary.filter.button.no@}</button>
+        <button id="filter-button-no" type="button" class="btn btn-secondary btn-sm">{@mapBuilder~dictionary.filter.button.no@}</button>
         <div id="filter-buttons" class="btn-group-toggle" data-toggle="buttons">
           <label class="btn btn-secondary btn-sm" id="filterButtonExtent">
             <input type="checkbox" name="Extent" autocomplete="off"> {@mapBuilder~dictionary.filter.button.extent@}
@@ -111,12 +111,12 @@
             <input type="checkbox" name="Keywords" autocomplete="off"> {@mapBuilder~dictionary.filter.button.keywords@}
           </label>
         </div>
-        <div id="filterKeywordsHandler">
-          <button id="filterKeywordsListButton" type="button" class="btn btn-sm btn-info dropdown-toggle">
+        <div id="filter-keywords-handler">
+          <button id="filter-keywords-list-button" type="button" class="btn btn-sm btn-info dropdown-toggle">
             {@mapBuilder~dictionary.filter.keywords.list@}
           </button>
-          <div id="filterKeywordsList" class="">
-            <div id="filterKeywordsListUtilsBar">
+          <div id="filter-keywords-list" class="">
+            <div id="filter-keywords-list-utils-bar">
               <div class="btn-group btn-group-toggle" data-toggle="buttons">
                 <label id="keywordsUnionButton" class="btn btn-outline-secondary btn-sm active">
                   <input type="radio" name="options" checked> {@mapBuilder~dictionary.filter.keywords.radio.union@}
@@ -129,7 +129,7 @@
                 <input id="keywordsFindInput" type="text" class="form-control" placeholder="{@mapBuilder~dictionary.filter.keywords.search.placeholder@}" aria-label="Username">
               </div>
             </div>
-            <div id="filterKeywordsListWords"></div>
+            <div id="filter-keywords-list-words"></div>
           </div>
         </div>
       </div>

--- a/mapBuilder/templates/main.tpl
+++ b/mapBuilder/templates/main.tpl
@@ -126,7 +126,7 @@
                 </label>
               </div>
               <div class="input-group input-group-sm ml-3 mr-2">
-                <input type="text" class="form-control" placeholder="{@mapBuilder~dictionary.filter.keywords.search.placeholder@}" aria-label="Username">
+                <input id="keywordsFindInput" type="text" class="form-control" placeholder="{@mapBuilder~dictionary.filter.keywords.search.placeholder@}" aria-label="Username">
               </div>
             </div>
             <div id="filterKeywordsListWords"></div>

--- a/mapBuilder/templates/main.tpl
+++ b/mapBuilder/templates/main.tpl
@@ -102,15 +102,13 @@
         <span id="layers-loading"></span>
       </div>
       <div id="layer-store-holder">
+        <button id="filterButtonNo" type="button" class="btn btn-secondary btn-sm">{@mapBuilder~dictionary.filter.button.no@}</button>
         <div id="filter-buttons" class="btn-group-toggle" data-toggle="buttons">
-          <label class="btn btn-secondary btn-sm active"  id="filterButtonNo">
-            <input type="radio" name="No" autocomplete="off" checked> {@mapBuilder~dictionary.filter.button.no@}
-          </label>
           <label class="btn btn-secondary btn-sm" id="filterButtonExtent">
-            <input type="radio" name="Extent" autocomplete="off"> {@mapBuilder~dictionary.filter.button.extent@}
+            <input type="checkbox" name="Extent" autocomplete="off"> {@mapBuilder~dictionary.filter.button.extent@}
           </label>
           <label class="btn btn-secondary btn-sm" id="filterButtonKeywords">
-            <input type="radio" name="Keywords" autocomplete="off"> {@mapBuilder~dictionary.filter.button.keywords@}
+            <input type="checkbox" name="Keywords" autocomplete="off"> {@mapBuilder~dictionary.filter.button.keywords@}
           </label>
         </div>
         <div id="filterKeywordsHandler">

--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -234,6 +234,7 @@ span.layer-store-folder {
 
 #layer-store-holder {
     margin: 15px 10px;
+    max-width: 40vw;
 }
 
 #layer-store-holder ul {
@@ -484,8 +485,66 @@ custom-slider .thumb {
     margin-bottom: 12px;
     flex-wrap: wrap;
     gap: 10px;
+    cursor: pointer;
+}
+
+#filterKeywordsHandler {
+    display: none;
+    justify-content: space-around;
+    flex-wrap: wrap;
+    gap: 10px;
+    max-width: 390px;
+    margin: auto auto 12px auto;
+    width: 90%;
+}
+
+#filterKeywordsHandler.active {
+    display: flex;
 }
 
 #filter-buttons > label:first-child {
     width: 100%;
+}
+
+#filterKeywordsListButton {
+    width: 100%;
+    z-index: 2;
+}
+
+#filterKeywordsList {
+    width: 100%;
+    margin-top: -20px;
+    z-index: 1;
+    padding: 5px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    font-size: .875rem;
+    border-radius: 0 0 8px 8px;
+    overflow-y: scroll;
+    max-height: 0px;
+    transition: ease 0.3s;
+}
+
+#filterKeywordsList.active {
+    max-height: 120px;
+    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.3);
+    margin-top: -12px;
+}
+
+#filterKeyword {
+    margin: 5px;
+    cursor: pointer;
+    padding: 5px 9px;
+    border-radius: 7px;
+    transition: ease 0.1s;
+}
+
+#filterKeyword:hover {
+    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.2);
+}
+
+#filterKeyword.active {
+    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.2);
+    background-color: #e2f4ff;
 }

--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -515,7 +515,6 @@ custom-slider .thumb {
     width: 100%;
     margin-top: -20px;
     z-index: 1;
-    padding: 5px;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
@@ -527,9 +526,24 @@ custom-slider .thumb {
 }
 
 #filterKeywordsList.active {
-    max-height: 120px;
+    max-height: 145px;
     box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.3);
     margin-top: -12px;
+}
+
+#filterKeywordsListWords {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 3px;
+}
+
+#filterKeywordsListUtilsBar {
+    width: 100%;
+    display: flex;
+    margin: 8px 8px 0;
+    align-items: center;
 }
 
 #filterKeyword {

--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -578,3 +578,7 @@ custom-slider .thumb {
     box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.2);
     background-color: #e2f4ff;
 }
+
+#filterKeywordsListWords.inter > #filterKeyword.active {
+    background-color: #ffe2e2;
+}

--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -479,6 +479,26 @@ custom-slider .thumb {
 
 /* CSS for filtering buttons */
 
+#filterButtonNo {
+    width: 100%;
+    color: #fff;
+    background-color: #6c757d;
+    border-color: #6c757d;
+    margin-bottom: 10px
+}
+
+#filterButtonNo:hover {
+    color: #fff;
+    background-color: #5a6268;
+    border-color: #545b62;
+}
+
+#filterButtonNo:active {
+    color: #fff;
+    background-color: #545b62;
+    border-color: #4e555b;
+}
+
 #filter-buttons {
     display: flex;
     justify-content: space-around;
@@ -500,10 +520,6 @@ custom-slider .thumb {
 
 #filterKeywordsHandler.active {
     display: flex;
-}
-
-#filter-buttons > label:first-child {
-    width: 100%;
 }
 
 #filterKeywordsListButton {

--- a/mapBuilder/www/css/main.css
+++ b/mapBuilder/www/css/main.css
@@ -479,7 +479,7 @@ custom-slider .thumb {
 
 /* CSS for filtering buttons */
 
-#filterButtonNo {
+#filter-button-no {
     width: 100%;
     color: #fff;
     background-color: #6c757d;
@@ -487,13 +487,13 @@ custom-slider .thumb {
     margin-bottom: 10px
 }
 
-#filterButtonNo:hover {
+#filter-button-no:hover {
     color: #fff;
     background-color: #5a6268;
     border-color: #545b62;
 }
 
-#filterButtonNo:active {
+#filter-button-no:active {
     color: #fff;
     background-color: #545b62;
     border-color: #4e555b;
@@ -508,26 +508,26 @@ custom-slider .thumb {
     cursor: pointer;
 }
 
-#filterKeywordsHandler {
+#filter-keywords-handler {
     display: none;
     justify-content: space-around;
     flex-wrap: wrap;
     gap: 10px;
     max-width: 390px;
-    margin: auto auto 12px auto;
+    margin: auto auto 12px;
     width: 90%;
 }
 
-#filterKeywordsHandler.active {
+#filter-keywords-handler.active {
     display: flex;
 }
 
-#filterKeywordsListButton {
+#filter-keywords-list-button {
     width: 100%;
     z-index: 2;
 }
 
-#filterKeywordsList {
+#filter-keywords-list {
     width: 100%;
     margin-top: -20px;
     z-index: 1;
@@ -537,17 +537,17 @@ custom-slider .thumb {
     font-size: .875rem;
     border-radius: 0 0 8px 8px;
     overflow-y: scroll;
-    max-height: 0px;
+    max-height: 0;
     transition: ease 0.3s;
 }
 
-#filterKeywordsList.active {
+#filter-keywords-list.active {
     max-height: 145px;
-    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 0 4px 0.3px rgb(0 0 0 / 30%);
     margin-top: -12px;
 }
 
-#filterKeywordsListWords {
+#filter-keywords-list-words {
     width: 100%;
     display: flex;
     flex-wrap: wrap;
@@ -555,14 +555,14 @@ custom-slider .thumb {
     padding: 3px;
 }
 
-#filterKeywordsListUtilsBar {
+#filter-keywords-list-utils-bar {
     width: 100%;
     display: flex;
     margin: 8px 8px 0;
     align-items: center;
 }
 
-#filterKeyword {
+#filter-keyword {
     margin: 5px;
     cursor: pointer;
     padding: 5px 9px;
@@ -570,15 +570,15 @@ custom-slider .thumb {
     transition: ease 0.1s;
 }
 
-#filterKeyword:hover {
-    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.2);
+#filter-keyword:hover {
+    box-shadow: 0 0 4px 0.3px rgb(0 0 0 / 20%);
 }
 
-#filterKeyword.active {
-    box-shadow: 0 0 4px 0.3px rgba(0, 0, 0, 0.2);
+#filter-keyword.active {
+    box-shadow: 0 0 4px 0.3px rgb(0 0 0 / 20%);
     background-color: #e2f4ff;
 }
 
-#filterKeywordsListWords.inter > #filterKeyword.active {
+#filter-keywords-list-words.inter > #filter-keyword.active {
     background-color: #ffe2e2;
 }

--- a/mapBuilder/www/js/components/LayerStore.js
+++ b/mapBuilder/www/js/components/LayerStore.js
@@ -17,11 +17,13 @@ export class LayerStore extends HTMLElement {
     /**
      * Create a layer store.
      * @param {HTMLElement} container The HTMLElement where the layer store will be rendered.
-     */
-    constructor(container) {
+     * @param {KeywordsManager} keywordsManager The keywords manager.
+   */
+    constructor(container, keywordsManager) {
         super();
         this.container = container;
         this.tree = [];
+    this.keywordsManager = keywordsManager;
 
         mapBuilder.layerStoreTree.forEach((value) => {
             this.tree.push(new LayerTreeFolder({
@@ -221,19 +223,25 @@ export class LayerStore extends HTMLElement {
 
     /**
      * Load the project and create the tree.
-     * @param {LayerTreeFolder} folder Folder with specs of the project to load.
+     * @param {LayerTreeProject} project Folder with specs of the project to load.
      * @returns {Promise<[]>} The children of the folder.
      */
-    async loadTree(folder) {
-        var repositoryId = folder.getRepository();
-        var projectId = folder.getProject();
+    async loadTree(project) {
+        var repositoryId = project.getRepository();
+        var projectId = project.getProject();
         var url = lizUrls.wms + "?repository=" + repositoryId + "&project=" + projectId + "&SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0";
         var parser = new WMSCapabilities();
 
         const promises = [
             new Promise(resolve => {
-                $.get(url, function (capabilities) {
+                $.get(url, (capabilities) => {
                     var result = parser.read(capabilities);
+
+            const wordList = result["Service"]["KeywordList"]
+
+            this.keywordsManager.addKeywordFromList(wordList);
+            project.setKeywords(wordList);
+
                     if (result.hasOwnProperty('Capability')) {
                         var node = result.Capability;
 

--- a/mapBuilder/www/js/components/LayerStore.js
+++ b/mapBuilder/www/js/components/LayerStore.js
@@ -17,13 +17,13 @@ export class LayerStore extends HTMLElement {
     /**
      * Create a layer store.
      * @param {HTMLElement} container The HTMLElement where the layer store will be rendered.
-     * @param {KeywordsManager} keywordsManager The keywords manager.
-   */
+     * @param {import("../modules/Filter/KeywordsManager").KeywordsManager} keywordsManager The keywords manager.
+     */
     constructor(container, keywordsManager) {
         super();
         this.container = container;
         this.tree = [];
-    this.keywordsManager = keywordsManager;
+        this.keywordsManager = keywordsManager;
 
         mapBuilder.layerStoreTree.forEach((value) => {
             this.tree.push(new LayerTreeFolder({
@@ -237,10 +237,10 @@ export class LayerStore extends HTMLElement {
                 $.get(url, (capabilities) => {
                     var result = parser.read(capabilities);
 
-            const wordList = result["Service"]["KeywordList"]
+                    const wordList = result["Service"]["KeywordList"]
 
-            this.keywordsManager.addKeywordFromList(wordList);
-            project.setKeywords(wordList);
+                    this.keywordsManager.addKeywordFromList(wordList);
+                    project.setKeywords(wordList);
 
                     if (result.hasOwnProperty('Capability')) {
                         var node = result.Capability;

--- a/mapBuilder/www/js/main.js
+++ b/mapBuilder/www/js/main.js
@@ -490,6 +490,18 @@ $(function() {
       keywordsManager.setCalculationMethod("intersect");
       filter();
     });
+
+    const textInputKeywords = document.getElementById("keywordsFindInput");
+
+    let timeout;
+
+    textInputKeywords.addEventListener("input", function () {
+      clearTimeout(timeout);
+
+      timeout = setTimeout(() => {
+        keywordsManager.refreshKeywordsFromSearch(textInputKeywords.value);
+      }, 400);
+    });
   }
 
   /**

--- a/mapBuilder/www/js/main.js
+++ b/mapBuilder/www/js/main.js
@@ -370,16 +370,11 @@ $(function() {
             });
         }
 
-        // Filter if is active
-        if (!document.getElementById("filterButtonNo").classList.contains("active")) {
-
-            const filterInstance = new ExtentFilter(listTree);
-
-            filterInstance.filter().then(() => {
-                endFilter();
-            });
-        }
+    // Filter if is active
+    if (!document.getElementById("filterButtonNo").classList.contains("active")) {
+      filterByExtent()
     }
+  }
 
     mapBuilder.map.on('moveend', onMoveEnd);
 
@@ -446,10 +441,8 @@ $(function() {
     // Keywords manager
   let keywordsManager = new KeywordsManager();
 
-  document.addEventListener('keywordsUpdated', async () => {
-    const filterInstance = new KeywordsFilter(listTree, keywordsManager.getSelectedKeywords());
-    await filterInstance.filter();
-    layerStore.updateTree(listTree);
+  document.addEventListener('keywordsUpdated', () => {
+    filterByKeywords();
   });
 
   //Build the tree
@@ -472,19 +465,15 @@ $(function() {
         document.querySelectorAll('#filter-buttons > label').forEach(button => {
             const filterName = button.children[0].name;
 
-      button.addEventListener("click", async () => {
+      button.addEventListener("click", () => {
         resetTree();
 
         if (filterName === "Extent") {
-          const filterInstance = new ExtentFilter(listTree);
-          await filterInstance.filter();
+          filterByExtent()
 
         } else if (filterName === "Keywords") {
-          const filterInstance = new KeywordsFilter(listTree, keywordsManager.getSelectedKeywords());
-          await filterInstance.filter();
+          filterByKeywords()
         }
-
-        layerStore.updateTree(listTree);
       });
     });
   }
@@ -502,19 +491,38 @@ $(function() {
         list.classList.add("active");
       }
     });
+
+    document.getElementById("keywordsUnionButton").addEventListener("click", function() {
+      keywordsManager.setCalculationMethod("union");
+      filterByKeywords();
+    });
+
+    document.getElementById("keywordsIntersectButton").addEventListener("click", function() {
+      keywordsManager.setCalculationMethod("intersect");
+      filterByKeywords();
+    });
+  }
+
+  async function filterByExtent() {
+    const filterInstance = new ExtentFilter(listTree);
+    await filterInstance.filter();
+    layerStore.updateTree(listTree);
+  }
+
+  async function filterByKeywords() {
+    const filterInstance = new KeywordsFilter(listTree, keywordsManager.getSelectedKeywords(), keywordsManager.getCalculationMethod());
+    await filterInstance.filter();
+    layerStore.updateTree(listTree);
   }
 
   function resetTree() {
     listTree = layerStore.setProjectAllVisible();
     document.getElementById("filterKeywordsList").classList.remove("active");
     document.getElementById("filterKeywordsHandler").classList.remove("active");
-  }/**
-     * End filter process by updating the tree.
-     */
-    const endFilter = () => {
+
         layerStore.updateTree(listTree);
-        listTree = layerStore.getTree();
-    };
+
+    }
 
     /* Handle custom addLayerButton clicks */
     document.querySelector('#layer-store-holder').addEventListener('click', function (e) {

--- a/mapBuilder/www/js/main.js
+++ b/mapBuilder/www/js/main.js
@@ -370,9 +370,9 @@ $(function() {
             });
         }
 
-    // Filter if is active
-    filter();
-  }
+        // Filter if is active
+        filter();
+    }
 
     mapBuilder.map.on('moveend', onMoveEnd);
 
@@ -437,13 +437,13 @@ $(function() {
     });
 
     // Keywords manager
-  let keywordsManager = new KeywordsManager();
+    let keywordsManager = new KeywordsManager();
 
-  document.addEventListener('keywordsUpdated', () => {
-    filter();
-  });
+    document.addEventListener('keywordsUpdated', () => {
+        filter();
+    });
 
-  //Build the tree
+    //Build the tree
     var listTree = [];
 
     var layerStore;
@@ -454,114 +454,124 @@ $(function() {
 
     // Carry filter buttons
     let listFilters = {
-    Extent: new ExtentFilter(layerStore),
-    Keywords: new KeywordsFilter(layerStore, keywordsManager)
-  };
-  let selectedFilters = [];
-  initFilterButtons();
-  initEventKeywordsFilters();
+        Extent: new ExtentFilter(layerStore),
+        Keywords: new KeywordsFilter(layerStore, keywordsManager)
+    };
+    let selectedFilters = [];
+    initFilterButtons();
+    initEventKeywordsFilters();
 
-  function initEventKeywordsFilters() {
-    const button = document.getElementById("filterButtonKeywords");
+    /**
+     * Initializes event listeners for managing keyword filters in the UI.
+     */
+    function initEventKeywordsFilters() {
+        const button = document.getElementById("filterButtonKeywords");
 
-    button.addEventListener("click", function() {
-      if (!button.classList.contains("active")) {
-        document.getElementById("filterKeywordsHandler").classList.add("active");
-      } else {
-        document.getElementById("filterKeywordsHandler").classList.remove("active");
-      }
-    });
+        button.addEventListener("click", function() {
+            if (!button.classList.contains("active")) {
+                document.getElementById("filter-keywords-handler").classList.add("active");
+            } else {
+                document.getElementById("filter-keywords-handler").classList.remove("active");
+            }
+        });
 
-    document.getElementById("filterKeywordsListButton").addEventListener("click", function() {
-      const list = document.getElementById("filterKeywordsList")
-      if (list.classList.contains("active")) {
-        list.classList.remove("active");
-      } else {
-        list.classList.add("active");
-      }
-    });
+        document.getElementById("filter-keywords-list-button").addEventListener("click", function() {
+            const list = document.getElementById("filter-keywords-list")
+            if (list.classList.contains("active")) {
+                list.classList.remove("active");
+            } else {
+                list.classList.add("active");
+            }
+        });
 
-    document.getElementById("keywordsUnionButton").addEventListener("click", function() {
-      keywordsManager.setCalculationMethod("union");
-      document.getElementById("filterKeywordsListButton").classList.replace("btn-danger", "btn-info");
-      document.getElementById("filterKeywordsListWords").classList.remove("inter");
-      filter();
-    });
+        document.getElementById("keywordsUnionButton").addEventListener("click", function() {
+            keywordsManager.setCalculationMethod("union");
+            document.getElementById("filter-keywords-list-button").classList.replace("btn-danger", "btn-info");
+            document.getElementById("filter-keywords-list-words").classList.remove("inter");
+            filter();
+        });
 
-    document.getElementById("keywordsIntersectButton").addEventListener("click", function() {
-      keywordsManager.setCalculationMethod("intersect");
-      document.getElementById("filterKeywordsListButton").classList.replace("btn-info", "btn-danger");
-      document.getElementById("filterKeywordsListWords").classList.add("inter");
-      filter();
-    });
+        document.getElementById("keywordsIntersectButton").addEventListener("click", function() {
+            keywordsManager.setCalculationMethod("intersect");
+            document.getElementById("filter-keywords-list-button").classList.replace("btn-info", "btn-danger");
+            document.getElementById("filter-keywords-list-words").classList.add("inter");
+            filter();
+        });
 
-    const textInputKeywords = document.getElementById("keywordsFindInput");
+        const textInputKeywords = document.getElementById("keywordsFindInput");
 
-    let timeout;
+        let timeout;
 
-    textInputKeywords.addEventListener("input", function () {
-      clearTimeout(timeout);
+        textInputKeywords.addEventListener("input", function () {
+            clearTimeout(timeout);
 
-      timeout = setTimeout(() => {
-        keywordsManager.refreshKeywordsFromSearch(textInputKeywords.value);
-      }, 400);
-    });
-  }
+            timeout = setTimeout(() => {
+                keywordsManager.refreshKeywordsFromSearch(textInputKeywords.value);
+            }, 400);
+        });
+    }
 
-  /**
-   * Initialize filter buttons.
-   */
-  function initFilterButtons() {
+    /**
+     * Initialize filter buttons.
+     */
+    function initFilterButtons() {
     // ButtonNoFilter
-    document.getElementById("filterButtonNo").addEventListener("click", function() {
-      selectedFilters = [];
-      resetTree();
-      document.getElementById("filterButtonExtent").classList.remove("active");
-      document.getElementById("filterButtonKeywords").classList.remove("active");
-    });
+        document.getElementById("filter-button-no").addEventListener("click", function() {
+            selectedFilters = [];
+            resetTree();
+            document.getElementById("filterButtonExtent").classList.remove("active");
+            document.getElementById("filterButtonKeywords").classList.remove("active");
+        });
 
-    const filtersUpdate = new CustomEvent('selectedFiltersUpdated');
+        const filtersUpdate = new CustomEvent('selectedFiltersUpdated');
 
-    document.querySelectorAll('#filter-buttons > label').forEach(button => {
-      const filterName = button.children[0].name;
+        document.querySelectorAll('#filter-buttons > label').forEach(button => {
+            const filterName = button.children[0].name;
 
-      button.addEventListener("click", () => {
-        if (!button.classList.contains("active")) {
-          selectedFilters.push(filterName);
-          document.dispatchEvent(filtersUpdate);
+            button.addEventListener("click", () => {
+                if (!button.classList.contains("active")) {
+                    selectedFilters.push(filterName);
+                    document.dispatchEvent(filtersUpdate);
+                } else {
+                    selectedFilters.splice(selectedFilters.indexOf(filterName), 1);
+                    document.dispatchEvent(filtersUpdate);
+                }
+            });
+        });
+    }
+
+    document.addEventListener('selectedFiltersUpdated', () => {
+        if (selectedFilters.length < 1) {
+            resetTree();
         } else {
-          selectedFilters.splice(selectedFilters.indexOf(filterName), 1);
-          document.dispatchEvent(filtersUpdate);
+            resetTree(false)
+            filter();
         }
-      });
     });
-  }
 
-  document.addEventListener('selectedFiltersUpdated', () => {
-    if (selectedFilters.length < 1) {
-      resetTree();
-    } else {
-      resetTree(false)
-      filter();
+    /**
+     * This method iterates through an array of selected filters, applying each filter function from the `listFilters` object.
+     */
+    async function filter() {
+        layerStore.setProjectAllVisible();
+
+        for (let i = 0; i < selectedFilters.length; i++) {
+            listFilters[selectedFilters[i]].filter();
+        }
     }
-  });
 
-  async function filter() {
-    layerStore.setProjectAllVisible();
-
-    for (let i = 0; i < selectedFilters.length; i++) {
-      listFilters[selectedFilters[i]].filter();
-    }
-  }
-
-  function resetTree(complete = true) {
-    listTree = layerStore.setProjectAllVisible();
-    if (complete) {
-    document.getElementById("filterKeywordsList").classList.remove("active");
-    document.getElementById("filterKeywordsHandler").classList.remove("active");
-}
+    /**
+     * Resets the state of the tree structure and updates it.
+     * If the `complete` parameter is set to true, additional UI elements are reset.
+     * @param {boolean} [complete] - Indicates if a complete reset should occur, including UI elements.
+     */
+    function resetTree(complete = true) {
+        listTree = layerStore.setProjectAllVisible();
+        if (complete) {
+            document.getElementById("filter-keywords-list").classList.remove("active");
+            document.getElementById("filter-keywords-handler").classList.remove("active");
+        }
         layerStore.updateTree(listTree);
-
     }
 
     /* Handle custom addLayerButton clicks */

--- a/mapBuilder/www/js/main.js
+++ b/mapBuilder/www/js/main.js
@@ -483,11 +483,15 @@ $(function() {
 
     document.getElementById("keywordsUnionButton").addEventListener("click", function() {
       keywordsManager.setCalculationMethod("union");
+      document.getElementById("filterKeywordsListButton").classList.replace("btn-danger", "btn-info");
+      document.getElementById("filterKeywordsListWords").classList.remove("inter");
       filter();
     });
 
     document.getElementById("keywordsIntersectButton").addEventListener("click", function() {
       keywordsManager.setCalculationMethod("intersect");
+      document.getElementById("filterKeywordsListButton").classList.replace("btn-info", "btn-danger");
+      document.getElementById("filterKeywordsListWords").classList.add("inter");
       filter();
     });
 

--- a/mapBuilder/www/js/modules/Filter/AbstractFilter.js
+++ b/mapBuilder/www/js/modules/Filter/AbstractFilter.js
@@ -1,14 +1,13 @@
-import { LayerTreeFolder } from "../LayerTree/LayerTreeFolder";
 import { LayerTreeProject } from "../LayerTree/LayerTreeProject";
 
 export class AbstractFilter {
 
     /**
      * Filter the layer tree.
-     * @param {LayerTreeFolder[]} layerTree - Layer tree to filter.
+     * @param {import("../../components/LayerStore").LayerStore} layerStore - Layer Store tree to filter.
      */
     constructor(layerStore) {
-      this._layerStore = layerStore;
+        this._layerStore = layerStore;
     }
 
     /**

--- a/mapBuilder/www/js/modules/Filter/AbstractFilter.js
+++ b/mapBuilder/www/js/modules/Filter/AbstractFilter.js
@@ -7,23 +7,27 @@ export class AbstractFilter {
      * Filter the layer tree.
      * @param {LayerTreeFolder[]} layerTree - Layer tree to filter.
      */
-    constructor(layerTree) {
-        this._layerTree = layerTree;
+    constructor(layerStore) {
+      this._layerStore = layerStore;
     }
 
     /**
      * Filter the layer tree.
      */
-    async filter() {
+    filter() {
+        this._layerTree = this._layerStore.getTree();
         for (let i = 0; i < this._layerTree.length; i++) {
             this._currentFolder = this._layerTree[i];
             for (let k = 0; k < this._currentFolder.getChildren().length; k++) {
                 if (this._currentFolder.getChildren()[k] instanceof LayerTreeProject) {
                     this._currentProject = this._currentFolder.getChildren()[k]
-                    this.filterProj(this._currentProject);
+                    if (this._currentProject.isVisible()) {
+                        this.filterProj(this._currentProject);
+                    }
                 }
             }
         }
+        this._layerStore.updateTree(this._layerTree);
     }
 
     /**

--- a/mapBuilder/www/js/modules/Filter/FilterKeywords.js
+++ b/mapBuilder/www/js/modules/Filter/FilterKeywords.js
@@ -2,49 +2,47 @@ import { AbstractFilter } from "./AbstractFilter";
 
 export class KeywordsFilter extends AbstractFilter {
 
-  selectedKeywords;
-  method;
-
-  /**
-   * Filter the layer tree using keywords of layers.
-   * @param {[LayerTreeElement]} layerTree - Layer tree to filter.
-   */
-  constructor(layerTree, keywordManager) {
-    super(layerTree);
-    this.keywordManager = keywordManager;
-  }
-
-  setVariables() {
-    this.selectedKeywords = this.keywordManager.getSelectedKeywords();
-    this.method = this.keywordManager.getCalculationMethod();
-  }
-
-  /**
-   * Filters the given layer tree element using a recursive filter function.
-   * @param {import("../LayerTree/LayerTreeElement").LayerTreeElement} layerTreeElement - The layer tree element to be filtered.
-   */
-  filterProj(layerTreeElement) {
-    let layerKeywords = layerTreeElement.getKeywords();
-    this.calculateFilter(layerKeywords);
-  }
-
-  /**
-   * Calculate if the layer should be visible or not
-   * @param {string[]} layerKeywords - Keywords to filter with.
-   */
-  calculateFilter(layerKeywords) {
-    this.setVariables();
-    if (this.selectedKeywords.length < 1) {
-      return;
+    /**
+     * Filter the layer tree using keywords of layers.
+     * @param {[import("../LayerTree/LayerTreeElement").LayerTreeElement]} layerTree - Layer tree to filter.
+     * @param {import("./KeywordsManager").KeywordsManager} keywordManager - The keywords manager.
+     */
+    constructor(layerTree, keywordManager) {
+        super(layerTree);
+        this.keywordManager = keywordManager;
     }
 
-    let visibility;
-
-    if (this.method === "union") {
-      visibility = this.selectedKeywords.some(keyword => layerKeywords.includes(keyword));
-    } else {
-      visibility = this.selectedKeywords.every(keyword => layerKeywords.includes(keyword));
+    setVariables() {
+        this.selectedKeywords = this.keywordManager.getSelectedKeywords();
+        this.method = this.keywordManager.getCalculationMethod();
     }
-    this._currentProject.setVisible(visibility);
-  }
+
+    /**
+     * Filters the given layer tree element using a recursive filter function.
+     * @param {import("../LayerTree/LayerTreeElement").LayerTreeElement} layerTreeElement - The layer tree element to be filtered.
+     */
+    filterProj(layerTreeElement) {
+        let layerKeywords = layerTreeElement.getKeywords();
+        this.calculateFilter(layerKeywords);
+    }
+
+    /**
+     * Calculate if the layer should be visible or not
+     * @param {string[]} layerKeywords - Keywords to filter with.
+     */
+    calculateFilter(layerKeywords) {
+        this.setVariables();
+        if (this.selectedKeywords.length < 1) {
+            return;
+        }
+
+        let visibility;
+
+        if (this.method === "union") {
+            visibility = this.selectedKeywords.some(keyword => layerKeywords.includes(keyword));
+        } else {
+            visibility = this.selectedKeywords.every(keyword => layerKeywords.includes(keyword));
+        }
+        this._currentProject.setVisible(visibility);
+    }
 }

--- a/mapBuilder/www/js/modules/Filter/FilterKeywords.js
+++ b/mapBuilder/www/js/modules/Filter/FilterKeywords.js
@@ -6,9 +6,10 @@ export class KeywordsFilter extends AbstractFilter {
    * Filter the layer tree using keywords of layers.
    * @param {[LayerTreeElement]} layerTree - Layer tree to filter.
    */
-  constructor(layerTree, keywords) {
+  constructor(layerTree, keywords, method) {
     super(layerTree);
     this.keywords = keywords;
+    this.method = method;
   }
 
   /**
@@ -25,7 +26,17 @@ export class KeywordsFilter extends AbstractFilter {
    * @param {string[]} layerKeywords - Keywords to filter with.
    */
   calculateFilter(layerKeywords) {
-    const visibility = this.keywords.some(keyword => layerKeywords.includes(keyword));
+    if (this.keywords.length < 1) {
+      return false;
+    }
+
+    let visibility;
+
+    if (this.method === "union") {
+      visibility = this.keywords.some(keyword => layerKeywords.includes(keyword));
+    } else {
+      visibility = this.keywords.every(keyword => layerKeywords.includes(keyword));
+    }
     this._currentProject.setVisible(visibility);
   }
 }

--- a/mapBuilder/www/js/modules/Filter/FilterKeywords.js
+++ b/mapBuilder/www/js/modules/Filter/FilterKeywords.js
@@ -1,0 +1,31 @@
+import { AbstractFilter } from "./AbstractFilter";
+
+export class KeywordsFilter extends AbstractFilter {
+
+  /**
+   * Filter the layer tree using keywords of layers.
+   * @param {[LayerTreeElement]} layerTree - Layer tree to filter.
+   */
+  constructor(layerTree, keywords) {
+    super(layerTree);
+    this.keywords = keywords;
+  }
+
+  /**
+   * Filters the given layer tree element using a recursive filter function.
+   * @param {import("../LayerTree/LayerTreeElement").LayerTreeElement} layerTreeElement - The layer tree element to be filtered.
+   */
+  filterProj(layerTreeElement) {
+    let layerKeywords = layerTreeElement.getKeywords();
+    this.calculateFilter(layerKeywords);
+  }
+
+  /**
+   * Calculate if the layer should be visible or not
+   * @param {string[]} layerKeywords - Keywords to filter with.
+   */
+  calculateFilter(layerKeywords) {
+    const visibility = this.keywords.some(keyword => layerKeywords.includes(keyword));
+    this._currentProject.setVisible(visibility);
+  }
+}

--- a/mapBuilder/www/js/modules/Filter/FilterKeywords.js
+++ b/mapBuilder/www/js/modules/Filter/FilterKeywords.js
@@ -2,14 +2,21 @@ import { AbstractFilter } from "./AbstractFilter";
 
 export class KeywordsFilter extends AbstractFilter {
 
+  selectedKeywords;
+  method;
+
   /**
    * Filter the layer tree using keywords of layers.
    * @param {[LayerTreeElement]} layerTree - Layer tree to filter.
    */
-  constructor(layerTree, keywords, method) {
+  constructor(layerTree, keywordManager) {
     super(layerTree);
-    this.keywords = keywords;
-    this.method = method;
+    this.keywordManager = keywordManager;
+  }
+
+  setVariables() {
+    this.selectedKeywords = this.keywordManager.getSelectedKeywords();
+    this.method = this.keywordManager.getCalculationMethod();
   }
 
   /**
@@ -26,16 +33,17 @@ export class KeywordsFilter extends AbstractFilter {
    * @param {string[]} layerKeywords - Keywords to filter with.
    */
   calculateFilter(layerKeywords) {
-    if (this.keywords.length < 1) {
-      return false;
+    this.setVariables();
+    if (this.selectedKeywords.length < 1) {
+      return;
     }
 
     let visibility;
 
     if (this.method === "union") {
-      visibility = this.keywords.some(keyword => layerKeywords.includes(keyword));
+      visibility = this.selectedKeywords.some(keyword => layerKeywords.includes(keyword));
     } else {
-      visibility = this.keywords.every(keyword => layerKeywords.includes(keyword));
+      visibility = this.selectedKeywords.every(keyword => layerKeywords.includes(keyword));
     }
     this._currentProject.setVisible(visibility);
   }

--- a/mapBuilder/www/js/modules/Filter/KeywordsManager.js
+++ b/mapBuilder/www/js/modules/Filter/KeywordsManager.js
@@ -1,0 +1,60 @@
+export class KeywordsManager {
+
+  /**
+   * @type {string[]} Keywords.
+   */
+  keywords;
+  /**
+   * @type {string[]} Selected keywords.
+   */
+  selectedKeywords;
+
+  constructor() {
+    this.keywords = [];
+    this.selectedKeywords = [];
+  }
+
+  /**
+   * Add all keywords from a list without duplicates.
+   * @param keywordList
+   */
+  addKeywordFromList(keywordList) {
+    keywordList.forEach(keyword => {
+      if (!this.keywords.includes(keyword)) {
+        this.keywords.push(keyword);
+        this.addKeywordHtml(keyword);
+      }
+    });
+  }
+
+  addKeywordHtml(word) {
+    let div = document.createElement("div");
+
+    div.id = "filterKeyword";
+    div.innerText = word;
+
+    div.addEventListener("click", () => {
+      if (div.className.includes("active")) {
+        div.className = "";
+        this.selectedKeywords.splice(this.selectedKeywords.indexOf(word), 1);
+      } else {
+        div.className = "active";
+        this.selectedKeywords.push(word);
+      }
+
+      const event = new CustomEvent('keywordsUpdated');
+      document.dispatchEvent(event);
+    });
+
+    document.getElementById("filterKeywordsList").append(div);
+  }
+
+  getKeywords() {
+    return this.keywords;
+  }
+
+  getSelectedKeywords() {
+    return this.selectedKeywords;
+  }
+
+}

--- a/mapBuilder/www/js/modules/Filter/KeywordsManager.js
+++ b/mapBuilder/www/js/modules/Filter/KeywordsManager.js
@@ -1,102 +1,90 @@
 export class KeywordsManager {
 
-  /**
-   * @type {string[]} Keywords.
-   */
-  keywords;
-  /**
-   * @type {string[]} Selected keywords.
-   */
-  selectedKeywords;
-  /**
-   * @type {string} Calculation method for the filter.
-   */
-  calculationMethod = "union";
-
-  constructor() {
-    this.keywords = [];
-    this.visibleKeywords = [];
-    this.selectedKeywords = [];
-  }
-
-  /**
-   * Add all keywords from a list without duplicates.
-   * @param keywordList
-   */
-  addKeywordFromList(keywordList) {
-    keywordList.forEach(keyword => {
-      if (!this.keywords.includes(keyword)) {
-        this.keywords.push(keyword);
-      }
-    });
-    this.refreshKeywordsFromSearch(document.getElementById("keywordsFindInput").textContent);
-  }
-
-  handleKeywordHtml() {
-    this.removeAllVisibleKeywordsHtml();
-    this.addKeywordsHtml()
-  }
-
-  removeAllVisibleKeywordsHtml() {
-    document.getElementById("filterKeywordsListWords").innerHTML = "";
-  }
-
-  addKeywordsHtml() {
-    this.visibleKeywords.forEach(word => {
-      let div = document.createElement("div");
-
-      div.id = "filterKeyword";
-      div.innerText = word;
-
-      div.addEventListener("click", () => {
-        if (div.className.includes("active")) {
-          div.className = "";
-          this.selectedKeywords.splice(this.selectedKeywords.indexOf(word), 1);
-        } else {
-          div.className = "active";
-          this.selectedKeywords.push(word);
-        }
-
-        const event = new CustomEvent('keywordsUpdated');
-        document.dispatchEvent(event);
-      });
-
-      if (this.selectedKeywords.includes(word)) {
-        div.className = "active";
-      }
-
-      document.getElementById("filterKeywordsListWords").append(div);
-    });
-  }
-
-  refreshKeywordsFromSearch(searchContent) {
-    if (searchContent.length === "") {
-      this.visibleKeywords = this.keywords;
-    } else {
-      this.visibleKeywords = [];
-      this.keywords.forEach(word => {
-        if (word.toLowerCase().includes(searchContent.toLowerCase())) {
-          this.visibleKeywords.push(word);
-        }
-      });
+    constructor() {
+        this.keywords = [];
+        this.visibleKeywords = [];
+        this.selectedKeywords = [];
+        this.calculationMethod = "union";
     }
-    this.handleKeywordHtml();
-  }
 
-  getKeywords() {
-    return this.keywords;
-  }
+    /**
+     * Add all keywords from a list without duplicates.
+     * @param {string[]} keywordList - List of keywords to add.
+     */
+    addKeywordFromList(keywordList) {
+        keywordList.forEach(keyword => {
+            if (!this.keywords.includes(keyword)) {
+                this.keywords.push(keyword);
+            }
+        });
+        this.refreshKeywordsFromSearch(document.getElementById("keywordsFindInput").textContent);
+    }
 
-  getSelectedKeywords() {
-    return this.selectedKeywords;
-  }
+    handleKeywordHtml() {
+        this.removeAllVisibleKeywordsHtml();
+        this.addKeywordsHtml()
+    }
 
-  getCalculationMethod() {
-    return this.calculationMethod;
-  }
+    removeAllVisibleKeywordsHtml() {
+        document.getElementById("filter-keywords-list-words").innerHTML = "";
+    }
 
-  setCalculationMethod(method) {
-    return this.calculationMethod = method;
-  }
+    addKeywordsHtml() {
+        this.visibleKeywords.forEach(word => {
+            let div = document.createElement("div");
+
+            div.id = "filter-keyword";
+            div.innerText = word;
+
+            div.addEventListener("click", () => {
+                if (div.className.includes("active")) {
+                    div.className = "";
+                    this.selectedKeywords.splice(this.selectedKeywords.indexOf(word), 1);
+                } else {
+                    div.className = "active";
+                    this.selectedKeywords.push(word);
+                }
+
+                const event = new CustomEvent('keywordsUpdated');
+                document.dispatchEvent(event);
+            });
+
+            if (this.selectedKeywords.includes(word)) {
+                div.className = "active";
+            }
+
+            document.getElementById("filter-keywords-list-words").append(div);
+        });
+    }
+
+    refreshKeywordsFromSearch(searchContent) {
+        if (searchContent.length === "") {
+            this.visibleKeywords = this.keywords;
+        } else {
+            this.visibleKeywords = [];
+            this.keywords.forEach(word => {
+                if (word.toLowerCase().includes(searchContent.toLowerCase())) {
+                    this.visibleKeywords.push(word);
+                }
+            });
+        }
+        this.handleKeywordHtml();
+    }
+
+    getKeywords() {
+        return this.keywords;
+    }
+
+    getSelectedKeywords() {
+        return this.selectedKeywords;
+    }
+
+    getCalculationMethod() {
+        return this.calculationMethod;
+    }
+
+    setCalculationMethod(method) {
+        return this.calculationMethod = method;
+    }
 
 }

--- a/mapBuilder/www/js/modules/Filter/KeywordsManager.js
+++ b/mapBuilder/www/js/modules/Filter/KeywordsManager.js
@@ -15,6 +15,7 @@ export class KeywordsManager {
 
   constructor() {
     this.keywords = [];
+    this.visibleKeywords = [];
     this.selectedKeywords = [];
   }
 
@@ -26,31 +27,60 @@ export class KeywordsManager {
     keywordList.forEach(keyword => {
       if (!this.keywords.includes(keyword)) {
         this.keywords.push(keyword);
-        this.addKeywordHtml(keyword);
       }
+    });
+    this.refreshKeywordsFromSearch(document.getElementById("keywordsFindInput").textContent);
+  }
+
+  handleKeywordHtml() {
+    this.removeAllVisibleKeywordsHtml();
+    this.addKeywordsHtml()
+  }
+
+  removeAllVisibleKeywordsHtml() {
+    document.getElementById("filterKeywordsListWords").innerHTML = "";
+  }
+
+  addKeywordsHtml() {
+    this.visibleKeywords.forEach(word => {
+      let div = document.createElement("div");
+
+      div.id = "filterKeyword";
+      div.innerText = word;
+
+      div.addEventListener("click", () => {
+        if (div.className.includes("active")) {
+          div.className = "";
+          this.selectedKeywords.splice(this.selectedKeywords.indexOf(word), 1);
+        } else {
+          div.className = "active";
+          this.selectedKeywords.push(word);
+        }
+
+        const event = new CustomEvent('keywordsUpdated');
+        document.dispatchEvent(event);
+      });
+
+      if (this.selectedKeywords.includes(word)) {
+        div.className = "active";
+      }
+
+      document.getElementById("filterKeywordsListWords").append(div);
     });
   }
 
-  addKeywordHtml(word) {
-    let div = document.createElement("div");
-
-    div.id = "filterKeyword";
-    div.innerText = word;
-
-    div.addEventListener("click", () => {
-      if (div.className.includes("active")) {
-        div.className = "";
-        this.selectedKeywords.splice(this.selectedKeywords.indexOf(word), 1);
-      } else {
-        div.className = "active";
-        this.selectedKeywords.push(word);
-      }
-
-      const event = new CustomEvent('keywordsUpdated');
-      document.dispatchEvent(event);
-    });
-
-    document.getElementById("filterKeywordsListWords").append(div);
+  refreshKeywordsFromSearch(searchContent) {
+    if (searchContent.length === "") {
+      this.visibleKeywords = this.keywords;
+    } else {
+      this.visibleKeywords = [];
+      this.keywords.forEach(word => {
+        if (word.toLowerCase().includes(searchContent.toLowerCase())) {
+          this.visibleKeywords.push(word);
+        }
+      });
+    }
+    this.handleKeywordHtml();
   }
 
   getKeywords() {

--- a/mapBuilder/www/js/modules/Filter/KeywordsManager.js
+++ b/mapBuilder/www/js/modules/Filter/KeywordsManager.js
@@ -8,6 +8,10 @@ export class KeywordsManager {
    * @type {string[]} Selected keywords.
    */
   selectedKeywords;
+  /**
+   * @type {string} Calculation method for the filter.
+   */
+  calculationMethod = "union";
 
   constructor() {
     this.keywords = [];
@@ -46,7 +50,7 @@ export class KeywordsManager {
       document.dispatchEvent(event);
     });
 
-    document.getElementById("filterKeywordsList").append(div);
+    document.getElementById("filterKeywordsListWords").append(div);
   }
 
   getKeywords() {
@@ -55,6 +59,14 @@ export class KeywordsManager {
 
   getSelectedKeywords() {
     return this.selectedKeywords;
+  }
+
+  getCalculationMethod() {
+    return this.calculationMethod;
+  }
+
+  setCalculationMethod(method) {
+    return this.calculationMethod = method;
   }
 
 }

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
@@ -6,6 +6,7 @@ import {LayerTreeFolder} from "./LayerTreeFolder";
  *  @property {boolean} _loading Loading state of the folder.
  *  @property {boolean} _failed If the folder got a load error.
  * @property {boolean} _visible Visibility of the layer for filtering.
+ * @property {string[]} _keywords Keywords of the project.
  */
 export class LayerTreeProject extends LayerTreeFolder {
 
@@ -27,6 +28,8 @@ export class LayerTreeProject extends LayerTreeFolder {
         this._failed = false;
 
         this._visible = true;
+
+        this._keywords = [];
     }
 
     /**
@@ -90,5 +93,21 @@ export class LayerTreeProject extends LayerTreeFolder {
      */
     setVisible(visible) {
         this._visible = visible;
+    }
+
+    /**
+     * Set the keywords of the layer.
+     * @param {string[]} keywords Keywords of the layer.
+     */
+    setKeywords(keywords) {
+        this._keywords = keywords;
+    }
+
+    /**
+     * Get the keywords of the layer.
+     * @return {string[]} Keywords of the layer.
+     */
+    getKeywords() {
+        return this._keywords;
     }
 }

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeProject.js
@@ -105,7 +105,7 @@ export class LayerTreeProject extends LayerTreeFolder {
 
     /**
      * Get the keywords of the layer.
-     * @return {string[]} Keywords of the layer.
+     * @returns {string[]} Keywords of the layer.
      */
     getKeywords() {
         return this._keywords;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -89,7 +89,10 @@ import-lizmap-acl:
 		php lizmap/console.php acl2:add admins "lizmap.repositories.view" mapbuilder ; \
 		php lizmap/console.php acl2:add __anonymous "lizmap.repositories.view" testingproject ; \
 		php lizmap/console.php acl2:add users "lizmap.repositories.view" testingproject ; \
-		php lizmap/console.php acl2:add admins "lizmap.repositories.view" testingproject';
+		php lizmap/console.php acl2:add admins "lizmap.repositories.view" testingproject ; \
+		php lizmap/console.php acl2:add __anonymous "lizmap.repositories.view" airportstest ; \
+		php lizmap/console.php acl2:add users "lizmap.repositories.view" airportstest ; \
+		php lizmap/console.php acl2:add admins "lizmap.repositories.view" airportstest';
 	@echo "Set mapbuilder access"
 	docker compose exec -u $(LIZMAP_USER_ID) lizmap /bin/sh -c ' \
 		php lizmap/console.php acl2:add __anonymous "mapBuilder.access" ; \

--- a/tests/e2e/tests/mapbuilder.spec.js
+++ b/tests/e2e/tests/mapbuilder.spec.js
@@ -11,30 +11,32 @@ test.describe('Build with multiple layers', () => {
         const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
         await lizmapMapbuilderMainPage.goto();
 
-        // First row for both
-
+        // Open all folders
         const listFolder = await lizmapMapbuilderMainPage.getListFolder();
 
         for (let i = 0; i < listFolder.length; i++) {
             await listFolder[i].click();
         }
 
-        // Second row for both
-        await page.locator('li.layer-store-arrow.lazy:nth-child(2)').click()
-        await page.locator('li.layer-store-arrow.lazy').last().click()
+        // Second row
+        await page.getByRole('listitem').filter({ hasText: 'norwayPoints' }).click();
+        await page.getByRole('listitem').filter({ hasText: 'Project demo' }).click();
+        await page.getByRole('listitem').filter({ hasText: 'eastPoints' }).click();
+        await page.getByRole('listitem').filter({ hasText: 'Paris' }).click();
 
-        await page.waitForTimeout(500);
+        await page.waitForTimeout(250);
 
         // Tree all deployed
         // Add layers on map
-
         await page.locator('.layer-store-layer').first().click();
-        await page.locator('.layer-store-layer').last().click();
+        await page.locator('.layer-store-layer').nth(2).click();
     });
 
     test('Remove layer', async ({ page }) => {
         const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
         await lizmapMapbuilderMainPage.openSelectedLayersDock();
+
+        await page.waitForTimeout(250);
 
         await lizmapMapbuilderMainPage.deleteLayer(0);
 
@@ -48,37 +50,43 @@ test.describe('Build with multiple layers', () => {
         const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
         await lizmapMapbuilderMainPage.openSelectedLayersDock();
 
+        await page.waitForTimeout(250);
+
         const firstLayer = await lizmapMapbuilderMainPage.getSpecificLayer(0);
-        const firstLayerId = await firstLayer.getAttribute('id');
+        const firstLayerId = await firstLayer.getAttribute('data-ol-uid');
 
         const secondLayer = await lizmapMapbuilderMainPage.getSpecificLayer(1);
-        const secondLayerId = await secondLayer.getAttribute('id');
+        const secondLayerId = await secondLayer.getAttribute('data-ol-uid');
 
         await firstLayer.locator('div.change-order-down').first().click();
 
-        await expect(await lizmapMapbuilderMainPage.getSpecificLayer(0)).toHaveAttribute('id', secondLayerId);
-        await expect(await lizmapMapbuilderMainPage.getSpecificLayer(1)).toHaveAttribute('id', firstLayerId);
+        await expect(await lizmapMapbuilderMainPage.getSpecificLayer(0)).toHaveAttribute('data-ol-uid', secondLayerId);
+        await expect(await lizmapMapbuilderMainPage.getSpecificLayer(1)).toHaveAttribute('data-ol-uid', firstLayerId);
     });
 
     test('Drag\'n Drop', async ({ page }) => {
         const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
         await lizmapMapbuilderMainPage.openSelectedLayersDock();
 
+        await page.waitForTimeout(250);
+
         const firstLayer = await lizmapMapbuilderMainPage.getSpecificLayer(0)
-        const firstLayerId = await firstLayer.getAttribute('id');
+        const firstLayerId = await firstLayer.getAttribute('data-ol-uid');
 
         const secondLayer = await lizmapMapbuilderMainPage.getSpecificLayer(1)
-        const secondLayerId = await secondLayer.getAttribute('id');
+        const secondLayerId = await secondLayer.getAttribute('data-ol-uid');
 
         await firstLayer.dragTo(secondLayer);
 
-        await expect(await lizmapMapbuilderMainPage.getSpecificLayer(0)).toHaveAttribute('id', secondLayerId);
-        await expect(await lizmapMapbuilderMainPage.getSpecificLayer(1)).toHaveAttribute('id', firstLayerId);
+        await expect(await lizmapMapbuilderMainPage.getSpecificLayer(0)).toHaveAttribute('data-ol-uid', secondLayerId);
+        await expect(await lizmapMapbuilderMainPage.getSpecificLayer(1)).toHaveAttribute('data-ol-uid', firstLayerId);
     });
 
     test('Legend is filled', async ({ page }) => {
         const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
         await lizmapMapbuilderMainPage.openLegendDock();
+
+        await page.waitForTimeout(250);
 
         const elementsLegend = await lizmapMapbuilderMainPage.getLegendElements();
 
@@ -90,19 +98,64 @@ test.describe('Build with multiple layers', () => {
         const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
         await lizmapMapbuilderMainPage.openLayerStoreDock();
 
-        await page.locator('li.layer-store-arrow.lazy:nth-child(1)').click()
         await page.waitForTimeout(250);
-        await page.locator('.layer-store-layer').first().click();
-
-        const parentLocator = lizmapMapbuilderMainPage.layerStoreHolder.locator('.layer-store-tree');
-        let childrenCount = await parentLocator.locator(':scope > ul').count();
-
-        expect(childrenCount).toEqual(5);
 
         await lizmapMapbuilderMainPage.setLayerStoreExtentFilter();
 
-        childrenCount = await parentLocator.locator(':scope > ul').count();
+        await page.waitForTimeout(100);
 
-        expect(childrenCount).toEqual(2);
+        await expect(page.getByRole('listitem').filter({ hasText: 'Project demo' })).toBeVisible();
+        await expect(page.getByRole('listitem').filter({ hasText: 'Paris' })).toBeVisible();
+    });
+
+    test('Handle keywords union filter', async ({ page }) => {
+
+        const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
+        await lizmapMapbuilderMainPage.openLayerStoreDock();
+
+        await lizmapMapbuilderMainPage.setLayerStoreKeywordsFilter();
+        await lizmapMapbuilderMainPage.openCloseKeywordsList();
+
+        await lizmapMapbuilderMainPage.clickOnKeyword("france");
+        await lizmapMapbuilderMainPage.clickOnKeyword("east");
+
+        await expect(page.getByRole('listitem').filter({ hasText: 'Project demo' })).toBeVisible();
+        await expect(page.getByRole('listitem').filter({ hasText: 'eastPoints' })).toBeVisible();
+        await expect(page.getByRole('listitem').filter({ hasText: 'Paris' })).toBeVisible();
+    });
+
+    test('Handle keywords intersection filter', async ({ page }) => {
+
+        const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
+        await lizmapMapbuilderMainPage.openLayerStoreDock();
+
+        await lizmapMapbuilderMainPage.setLayerStoreKeywordsFilter();
+        await lizmapMapbuilderMainPage.openCloseKeywordsList();
+        await lizmapMapbuilderMainPage.setIntersectionKeywordsFilter();
+
+        await lizmapMapbuilderMainPage.clickOnKeyword("france");
+        await lizmapMapbuilderMainPage.clickOnKeyword("europe");
+
+        await expect(page.getByRole('listitem').filter({ hasText: 'Project demo' })).toBeVisible();
+        await expect(page.getByRole('listitem').filter({ hasText: 'Paris' })).toBeVisible();
+    });
+
+    test('Handle extent & keywords filter', async ({ page }) => {
+
+        const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
+        await lizmapMapbuilderMainPage.openLayerStoreDock();
+
+        await lizmapMapbuilderMainPage.setLayerStoreKeywordsFilter();
+        await lizmapMapbuilderMainPage.openCloseKeywordsList();
+
+        await lizmapMapbuilderMainPage.clickOnKeyword("france");
+        await lizmapMapbuilderMainPage.clickOnKeyword("east");
+
+        await lizmapMapbuilderMainPage.setLayerStoreExtentFilter();
+
+        await page.waitForTimeout(250);
+
+        await expect(page.getByRole('listitem').filter({ hasText: 'Project demo' })).toBeVisible();
+        await expect(page.getByRole('listitem').filter({ hasText: 'Paris' })).toBeVisible();
     });
 });

--- a/tests/e2e/tests/pom/lizmap-mapbuilder-main-page.js
+++ b/tests/e2e/tests/pom/lizmap-mapbuilder-main-page.js
@@ -174,7 +174,7 @@ exports.LizmapMapbuilderMainPage = class LizmapMapbuilderMainPage {
      * Sets the layer store configuration to "No Filter".
      */
     async setLayerStoreNoFilter() {
-        await this.page.locator("#filterButtonNo").click();
+        await this.page.locator("#filter-button-no").click();
     }
 
     /**
@@ -195,7 +195,7 @@ exports.LizmapMapbuilderMainPage = class LizmapMapbuilderMainPage {
      * Open list of keywords.
      */
     async openCloseKeywordsList() {
-        await this.page.locator("#filterKeywordsListButton").click();
+        await this.page.locator("#filter-keywords-list-button").click();
     }
 
     /**

--- a/tests/e2e/tests/pom/lizmap-mapbuilder-main-page.js
+++ b/tests/e2e/tests/pom/lizmap-mapbuilder-main-page.js
@@ -27,6 +27,7 @@ exports.LizmapMapbuilderMainPage = class LizmapMapbuilderMainPage {
         // Layer Store nav
         this.layerStoreHolder = page.locator("#layer-store-holder");
         this.baseLayerSelect = page.locator("#baseLayerSelect");
+        this.keywordsFinder = page.locator("#keywordsFindInput");
 
         // Selected Layers nav
         this.selectedLayerHolder = page.locator("#layer-selected-holder");
@@ -183,4 +184,39 @@ exports.LizmapMapbuilderMainPage = class LizmapMapbuilderMainPage {
         await this.page.locator("#filterButtonExtent").click();
     }
 
+    /**
+     * Sets the layer store configuration to "Keywords filter".
+     */
+    async setLayerStoreKeywordsFilter() {
+        await this.page.locator("#filterButtonKeywords").click();
+    }
+
+    /**
+     * Open list of keywords.
+     */
+    async openCloseKeywordsList() {
+        await this.page.locator("#filterKeywordsListButton").click();
+    }
+
+    /**
+     * Set the keywords filter to the "union" mode.
+     */
+    async setUnionKeywordsFilter() {
+        await this.page.locator("#keywordsUnionButton").click();
+    }
+
+    /**
+     * Set the keywords filter to the "intersection" mode.
+     */
+    async setIntersectionKeywordsFilter() {
+        await this.page.locator("#keywordsIntersectButton").click();
+    }
+
+    /**
+     * Clicks on a keyword element on the page.
+     * @param {string} keyword - The keyword text to locate and click on.
+     */
+    async clickOnKeyword(keyword) {
+        await this.page.getByText(keyword).click();
+    }
 };

--- a/tests/lizmap/etc/conf/lizmapconfig.d/lizmapConfig.ini.php
+++ b/tests/lizmap/etc/conf/lizmapconfig.d/lizmapConfig.ini.php
@@ -10,3 +10,8 @@ allowUserDefinedThemes=1
 label=Testing project
 path="/srv/projects/testing_project/"
 allowUserDefinedThemes=1
+
+[repository:airportstest]
+label=Airports test
+path="/srv/projects/airportsTest/"
+allowUserDefinedThemes=1

--- a/tests/lizmap/instances/airportsTest/Paris.qgs
+++ b/tests/lizmap/instances/airportsTest/Paris.qgs
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis saveUser="neo" saveUserFull="Neo" saveDateTime="2025-02-25T15:25:44" projectname="" version="3.34.4-Prizren">
+<qgis version="3.34.4-Prizren" saveUserFull="Neo" saveUser="neo" saveDateTime="2025-02-26T09:25:01" projectname="">
   <homePath path=""/>
   <title></title>
   <transaction mode="Disabled"/>
@@ -17,34 +17,34 @@
       <geographicflag>true</geographicflag>
     </spatialrefsys>
   </projectCrs>
-  <elevation-shading-renderer light-azimuth="315" edl-distance-unit="0" hillshading-is-active="0" edl-is-active="1" hillshading-is-multidirectional="0" hillshading-z-factor="1" edl-distance="0.5" edl-strength="1000" light-altitude="45" is-active="0" combined-method="0"/>
+  <elevation-shading-renderer hillshading-is-multidirectional="0" edl-is-active="1" is-active="0" edl-distance="0.5" combined-method="0" hillshading-is-active="0" hillshading-z-factor="1" edl-strength="1000" light-altitude="45" light-azimuth="315" edl-distance-unit="0"/>
   <layer-tree-group>
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer expanded="1" legend_exp="" name="points" checked="Qt::Checked" patch_size="-1,-1" legend_split_behavior="0" id="points_e6681b07_b7aa_47ec_b13a_d4a69a9c0762" source="./points.geojson" providerKey="ogr">
+    <layer-tree-layer id="paris_c0ea3b6c_b829_486e_9622_f9fd5f725029" patch_size="-1,-1" providerKey="ogr" legend_exp="" expanded="1" checked="Qt::Checked" legend_split_behavior="0" source="./airportsParis.geojson" name="buildings">
       <customproperties>
         <Option/>
       </customproperties>
     </layer-tree-layer>
     <custom-order enabled="0">
-      <item>points_e6681b07_b7aa_47ec_b13a_d4a69a9c0762</item>
+      <item>paris_c0ea3b6c_b829_486e_9622_f9fd5f725029</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings minScale="0" tolerance="12" maxScale="0" enabled="0" intersection-snapping="0" mode="2" type="1" unit="1" self-snapping="0" scaleDependencyMode="0">
+  <snapping-settings tolerance="12" intersection-snapping="0" mode="2" scaleDependencyMode="0" maxScale="0" enabled="0" minScale="0" unit="1" self-snapping="0" type="1">
     <individual-layer-settings>
-      <layer-setting minScale="0" tolerance="12" maxScale="0" enabled="0" type="1" units="1" id="points_e6681b07_b7aa_47ec_b13a_d4a69a9c0762"/>
+      <layer-setting id="paris_c0ea3b6c_b829_486e_9622_f9fd5f725029" tolerance="12" maxScale="0" enabled="0" minScale="0" type="1" units="1"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations/>
   <polymorphicRelations/>
-  <mapcanvas name="theMapCanvas" annotationsVisible="1">
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
     <units>degrees</units>
     <extent>
-      <xmin>6.85362601013294626</xmin>
-      <ymin>60.62045223831250951</ymin>
-      <xmax>6.8970365229460926</xmax>
-      <ymax>60.62045346232355314</ymax>
+      <xmin>2.36442826130212103</xmin>
+      <ymin>48.70164796200585755</ymin>
+      <xmax>2.58964530979775232</xmax>
+      <ymax>49.03180232230970859</ymax>
     </extent>
     <rotation>0</rotation>
     <destinationsrs>
@@ -65,14 +65,14 @@
   </mapcanvas>
   <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer checked="Qt::Checked" name="points" drawingOrder="-1" open="true" showFeatureCount="0">
-      <filegroup hidden="false" open="true">
-        <legendlayerfile layerid="points_e6681b07_b7aa_47ec_b13a_d4a69a9c0762" isInOverview="0" visible="1"/>
+    <legendlayer open="true" checked="Qt::Checked" showFeatureCount="0" name="buildings" drawingOrder="-1">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile isInOverview="0" layerid="paris_c0ea3b6c_b829_486e_9622_f9fd5f725029" visible="1"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
-  <main-annotation-layer minScale="1e+08" refreshOnNotifyMessage="" autoRefreshMode="Disabled" styleCategories="AllStyleCategories" maxScale="0" autoRefreshTime="0" type="annotation" hasScaleBasedVisibilityFlag="0" refreshOnNotifyEnabled="0" legendPlaceholderImage="">
+  <main-annotation-layer maxScale="0" refreshOnNotifyMessage="" autoRefreshMode="Disabled" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" minScale="1e+08" legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" autoRefreshTime="0" type="annotation">
     <id>Annotations_a789c14f_f2f8_49a2_b41f_d0cc496cc885</id>
     <datasource></datasource>
     <keywordList>
@@ -133,26 +133,26 @@
     <paintEffect/>
   </main-annotation-layer>
   <projectlayers>
-    <maplayer autoRefreshMode="Disabled" simplifyAlgorithm="0" minScale="100000000" simplifyLocal="1" legendPlaceholderImage="" readOnly="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="0" refreshOnNotifyMessage="" maxScale="0" autoRefreshTime="0" wkbType="Point" simplifyMaxScale="1" geometry="Point" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" type="vector" simplifyDrawingTol="1" symbologyReferenceScale="-1" labelsEnabled="0">
+    <maplayer autoRefreshMode="Disabled" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" minScale="100000000" readOnly="0" refreshOnNotifyMessage="" wkbType="Point" hasScaleBasedVisibilityFlag="0" simplifyMaxScale="1" autoRefreshTime="0" maxScale="0" legendPlaceholderImage="" geometry="Point" simplifyDrawingHints="0" simplifyAlgorithm="0" symbologyReferenceScale="-1" labelsEnabled="0" simplifyDrawingTol="1" type="vector" simplifyLocal="1">
       <extent>
-        <xmin>6.85400000000000009</xmin>
-        <ymin>60.62199999999999989</ymin>
-        <xmax>6.89700000000000024</xmax>
-        <ymax>60.62199999999999989</ymax>
+        <xmin>2.36773599999999984</xmin>
+        <ymin>48.72768299999999897</ymin>
+        <xmax>2.55809800000000021</xmax>
+        <ymax>49.00674200000000269</ymax>
       </extent>
       <wgs84extent>
-        <xmin>6.85400000000000009</xmin>
-        <ymin>60.62199999999999989</ymin>
-        <xmax>6.89700000000000024</xmax>
-        <ymax>60.62199999999999989</ymax>
+        <xmin>2.36773599999999984</xmin>
+        <ymin>48.72768299999999897</ymin>
+        <xmax>2.55809800000000021</xmax>
+        <ymax>49.00674200000000269</ymax>
       </wgs84extent>
-      <id>points_e6681b07_b7aa_47ec_b13a_d4a69a9c0762</id>
-      <datasource>./points.geojson</datasource>
-      <shortname>points</shortname>
+      <id>paris_c0ea3b6c_b829_486e_9622_f9fd5f725029</id>
+      <datasource>./airportsParis.geojson</datasource>
+      <shortname>paris</shortname>
       <keywordList>
         <value></value>
       </keywordList>
-      <layername>points</layername>
+      <layername>buildings</layername>
       <srs>
         <spatialrefsys nativeFormat="Wkt">
           <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
@@ -200,7 +200,7 @@
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minz="0" maxx="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" maxy="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" crs="EPSG:4326" minx="179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" dimensions="2" miny="179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" maxz="0"/>
+          <spatial miny="179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" minx="179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" maxx="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" maxz="0" crs="EPSG:4326" minz="0" dimensions="2" maxy="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368"/>
           <temporal>
             <period>
               <start></start>
@@ -225,181 +225,209 @@
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal startField="" accumulate="0" endField="" limitMode="0" durationUnit="min" enabled="0" fixedDuration="0" mode="0" durationField="id" endExpression="" startExpression="">
+      <temporal limitMode="0" endExpression="" endField="" mode="0" fixedDuration="0" durationUnit="min" startExpression="" accumulate="0" enabled="0" startField="" durationField="id">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation zoffset="0" respectLayerSymbol="1" extrusion="0" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" type="IndividualFeatures" zscale="1" binding="Centroid" extrusionEnabled="0">
+      <elevation symbology="Line" binding="Centroid" extrusionEnabled="0" zscale="1" zoffset="0" clamping="Terrain" showMarkerSymbolInSurfacePlots="0" extrusion="0" respectLayerSymbol="1" type="IndividualFeatures">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
+          <symbol clip_to_extent="1" force_rhr="0" is_animated="0" frame_rate="10" alpha="1" name="" type="line">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{b62987eb-1d8e-4c6d-b774-04e33e25b13a}">
+            <layer id="{bae86f62-38bb-4ef0-9809-279273eef685}" class="SimpleLine" pass="0" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="align_dash_pattern" value="0" type="QString"/>
-                <Option name="capstyle" value="square" type="QString"/>
-                <Option name="customdash" value="5;2" type="QString"/>
-                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="customdash_unit" value="MM" type="QString"/>
-                <Option name="dash_pattern_offset" value="0" type="QString"/>
-                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-                <Option name="draw_inside_polygon" value="0" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="line_color" value="164,113,88,255" type="QString"/>
-                <Option name="line_style" value="solid" type="QString"/>
-                <Option name="line_width" value="0.6" type="QString"/>
-                <Option name="line_width_unit" value="MM" type="QString"/>
-                <Option name="offset" value="0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="ring_filter" value="0" type="QString"/>
-                <Option name="trim_distance_end" value="0" type="QString"/>
-                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
-                <Option name="trim_distance_start" value="0" type="QString"/>
-                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
-                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-                <Option name="use_custom_dash" value="0" type="QString"/>
-                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option value="0" name="align_dash_pattern" type="QString"/>
+                <Option value="square" name="capstyle" type="QString"/>
+                <Option value="5;2" name="customdash" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+                <Option value="MM" name="customdash_unit" type="QString"/>
+                <Option value="0" name="dash_pattern_offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+                <Option value="0" name="draw_inside_polygon" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="114,155,111,255" name="line_color" type="QString"/>
+                <Option value="solid" name="line_style" type="QString"/>
+                <Option value="0.6" name="line_width" type="QString"/>
+                <Option value="MM" name="line_width_unit" type="QString"/>
+                <Option value="0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="0" name="ring_filter" type="QString"/>
+                <Option value="0" name="trim_distance_end" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+                <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+                <Option value="0" name="trim_distance_start" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+                <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+                <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+                <Option value="0" name="use_custom_dash" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol clip_to_extent="1" name="" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+          <symbol clip_to_extent="1" force_rhr="0" is_animated="0" frame_rate="10" alpha="1" name="" type="fill">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{5617f99a-ff00-44e2-81d4-ea78924feb64}">
+            <layer id="{cbe787ec-4b3a-4493-9f69-51710c56d93d}" class="SimpleFill" pass="0" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="color" value="164,113,88,255" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="117,81,63,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="style" value="solid" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale" type="QString"/>
+                <Option value="114,155,111,255" name="color" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="81,111,79,255" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0.2" name="outline_width" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="solid" name="style" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+          <symbol clip_to_extent="1" force_rhr="0" is_animated="0" frame_rate="10" alpha="1" name="" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{3f3b3bfa-fd7f-481b-a148-017da74913e6}">
+            <layer id="{86b6bc7c-84e1-410b-beff-6a54e05c1125}" class="SimpleMarker" pass="0" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" value="0" type="QString"/>
-                <Option name="cap_style" value="square" type="QString"/>
-                <Option name="color" value="164,113,88,255" type="QString"/>
-                <Option name="horizontal_anchor_point" value="1" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="name" value="diamond" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="117,81,63,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0.2" type="QString"/>
-                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="scale_method" value="diameter" type="QString"/>
-                <Option name="size" value="3" type="QString"/>
-                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="size_unit" value="MM" type="QString"/>
-                <Option name="vertical_anchor_point" value="1" type="QString"/>
+                <Option value="0" name="angle" type="QString"/>
+                <Option value="square" name="cap_style" type="QString"/>
+                <Option value="114,155,111,255" name="color" type="QString"/>
+                <Option value="1" name="horizontal_anchor_point" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="diamond" name="name" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="81,111,79,255" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0.2" name="outline_width" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="diameter" name="scale_method" type="QString"/>
+                <Option value="3" name="size" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+                <Option value="MM" name="size_unit" type="QString"/>
+                <Option value="1" name="vertical_anchor_point" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileMarkerSymbol>
       </elevation>
-      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
+      <renderer-v2 referencescale="-1" forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
         <symbols>
-          <symbol clip_to_extent="1" name="0" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+          <symbol clip_to_extent="1" force_rhr="0" is_animated="0" frame_rate="10" alpha="1" name="0" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{6e908ba9-21b0-4ad4-873a-b35afb84fec2}">
+            <layer id="{5ead9d5d-37d3-47c3-a7de-0f399957a362}" class="SvgMarker" pass="0" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" value="0" type="QString"/>
-                <Option name="cap_style" value="square" type="QString"/>
-                <Option name="color" value="0,229,4,255" type="QString"/>
-                <Option name="horizontal_anchor_point" value="1" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="name" value="circle" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="35,35,35,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0" type="QString"/>
-                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="scale_method" value="diameter" type="QString"/>
-                <Option name="size" value="15" type="QString"/>
-                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="size_unit" value="MM" type="QString"/>
-                <Option name="vertical_anchor_point" value="1" type="QString"/>
+                <Option value="0" name="angle" type="QString"/>
+                <Option value="0,0,0,255" name="color" type="QString"/>
+                <Option value="0" name="fixedAspectRatio" type="QString"/>
+                <Option value="1" name="horizontal_anchor_point" type="QString"/>
+                <Option value="transport/transport_airport.svg" name="name" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="255,255,255,255" name="outline_color" type="QString"/>
+                <Option value="0.6" name="outline_width" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option name="parameters"/>
+                <Option value="diameter" name="scale_method" type="QString"/>
+                <Option value="12" name="size" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+                <Option value="MM" name="size_unit" type="QString"/>
+                <Option value="1" name="vertical_anchor_point" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" name="type" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer id="{642ab2b4-2814-4c37-9bdc-d4ba3afb90d0}" class="SvgMarker" pass="0" locked="0" enabled="1">
+              <Option type="Map">
+                <Option value="0" name="angle" type="QString"/>
+                <Option value="0,0,0,255" name="color" type="QString"/>
+                <Option value="0" name="fixedAspectRatio" type="QString"/>
+                <Option value="1" name="horizontal_anchor_point" type="QString"/>
+                <Option value="transport/transport_airport.svg" name="name" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="255,255,255,255" name="outline_color" type="QString"/>
+                <Option value="0" name="outline_width" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option name="parameters"/>
+                <Option value="diameter" name="scale_method" type="QString"/>
+                <Option value="12" name="size" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+                <Option value="MM" name="size_unit" type="QString"/>
+                <Option value="1" name="vertical_anchor_point" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" name="name" type="QString"/>
+                  <Option name="properties"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -411,41 +439,41 @@
       <selection mode="Default">
         <selectionColor invalid="1"/>
         <selectionSymbol>
-          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+          <symbol clip_to_extent="1" force_rhr="0" is_animated="0" frame_rate="10" alpha="1" name="" type="marker">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" value="" type="QString"/>
+                <Option value="" name="name" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" value="collection" type="QString"/>
+                <Option value="collection" name="type" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{437cb079-0a38-4891-9397-3b8724903a56}">
+            <layer id="{f1cbd4dc-b847-40a8-8730-70a44ca5af74}" class="SimpleMarker" pass="0" locked="0" enabled="1">
               <Option type="Map">
-                <Option name="angle" value="0" type="QString"/>
-                <Option name="cap_style" value="square" type="QString"/>
-                <Option name="color" value="255,0,0,255" type="QString"/>
-                <Option name="horizontal_anchor_point" value="1" type="QString"/>
-                <Option name="joinstyle" value="bevel" type="QString"/>
-                <Option name="name" value="circle" type="QString"/>
-                <Option name="offset" value="0,0" type="QString"/>
-                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="offset_unit" value="MM" type="QString"/>
-                <Option name="outline_color" value="35,35,35,255" type="QString"/>
-                <Option name="outline_style" value="solid" type="QString"/>
-                <Option name="outline_width" value="0" type="QString"/>
-                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="outline_width_unit" value="MM" type="QString"/>
-                <Option name="scale_method" value="diameter" type="QString"/>
-                <Option name="size" value="2" type="QString"/>
-                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                <Option name="size_unit" value="MM" type="QString"/>
-                <Option name="vertical_anchor_point" value="1" type="QString"/>
+                <Option value="0" name="angle" type="QString"/>
+                <Option value="square" name="cap_style" type="QString"/>
+                <Option value="255,0,0,255" name="color" type="QString"/>
+                <Option value="1" name="horizontal_anchor_point" type="QString"/>
+                <Option value="bevel" name="joinstyle" type="QString"/>
+                <Option value="circle" name="name" type="QString"/>
+                <Option value="0,0" name="offset" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                <Option value="MM" name="offset_unit" type="QString"/>
+                <Option value="35,35,35,255" name="outline_color" type="QString"/>
+                <Option value="solid" name="outline_style" type="QString"/>
+                <Option value="0" name="outline_width" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale" type="QString"/>
+                <Option value="MM" name="outline_width_unit" type="QString"/>
+                <Option value="diameter" name="scale_method" type="QString"/>
+                <Option value="2" name="size" type="QString"/>
+                <Option value="3x:0,0,0,0,0,0" name="size_map_unit_scale" type="QString"/>
+                <Option value="MM" name="size_unit" type="QString"/>
+                <Option value="1" name="vertical_anchor_point" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -454,7 +482,7 @@
       </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="embeddedWidgets/count" value="0" type="int"/>
+          <Option value="0" name="embeddedWidgets/count" type="int"/>
           <Option name="variableNames" type="invalid"/>
           <Option name="variableValues" type="invalid"/>
         </Option>
@@ -462,54 +490,54 @@
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory scaleDependency="Area" sizeType="MM" spacingUnit="MM" direction="0" height="15" rotationOffset="270" barWidth="5" scaleBasedVisibility="0" penColor="#000000" minimumSize="0" spacingUnitScale="3x:0,0,0,0,0,0" backgroundAlpha="255" showAxis="1" opacity="1" minScaleDenominator="0" penAlpha="255" width="15" enabled="0" penWidth="0" diagramOrientation="Up" spacing="5" lineSizeType="MM" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" backgroundColor="#ffffff" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0">
-          <fontProperties bold="0" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" underline="0" style="" strikethrough="0"/>
-          <attribute field="" color="#000000" label="" colorOpacity="1"/>
+      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+        <DiagramCategory penColor="#000000" spacingUnitScale="3x:0,0,0,0,0,0" direction="0" opacity="1" showAxis="1" spacingUnit="MM" sizeType="MM" rotationOffset="270" barWidth="5" backgroundColor="#ffffff" enabled="0" width="15" backgroundAlpha="255" diagramOrientation="Up" height="15" scaleBasedVisibility="0" scaleDependency="Area" minimumSize="0" penAlpha="255" penWidth="0" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" spacing="5" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" minScaleDenominator="0" maxScaleDenominator="1e+08">
+          <fontProperties style="" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" strikethrough="0" bold="0" underline="0"/>
+          <attribute field="" label="" colorOpacity="1" color="#000000"/>
           <axisSymbol>
-            <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
+            <symbol clip_to_extent="1" force_rhr="0" is_animated="0" frame_rate="10" alpha="1" name="" type="line">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option value="" name="name" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option value="collection" name="type" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{c4a7ef6a-75eb-4688-a547-85b593bc199c}">
+              <layer id="{d0f67643-43b8-4a15-9aa9-39a3e77e7e64}" class="SimpleLine" pass="0" locked="0" enabled="1">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" value="0" type="QString"/>
-                  <Option name="capstyle" value="square" type="QString"/>
-                  <Option name="customdash" value="5;2" type="QString"/>
-                  <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="customdash_unit" value="MM" type="QString"/>
-                  <Option name="dash_pattern_offset" value="0" type="QString"/>
-                  <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
-                  <Option name="draw_inside_polygon" value="0" type="QString"/>
-                  <Option name="joinstyle" value="bevel" type="QString"/>
-                  <Option name="line_color" value="35,35,35,255" type="QString"/>
-                  <Option name="line_style" value="solid" type="QString"/>
-                  <Option name="line_width" value="0.26" type="QString"/>
-                  <Option name="line_width_unit" value="MM" type="QString"/>
-                  <Option name="offset" value="0" type="QString"/>
-                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="offset_unit" value="MM" type="QString"/>
-                  <Option name="ring_filter" value="0" type="QString"/>
-                  <Option name="trim_distance_end" value="0" type="QString"/>
-                  <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="trim_distance_end_unit" value="MM" type="QString"/>
-                  <Option name="trim_distance_start" value="0" type="QString"/>
-                  <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
-                  <Option name="trim_distance_start_unit" value="MM" type="QString"/>
-                  <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
-                  <Option name="use_custom_dash" value="0" type="QString"/>
-                  <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option value="0" name="align_dash_pattern" type="QString"/>
+                  <Option value="square" name="capstyle" type="QString"/>
+                  <Option value="5;2" name="customdash" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="customdash_unit" type="QString"/>
+                  <Option value="0" name="dash_pattern_offset" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="dash_pattern_offset_unit" type="QString"/>
+                  <Option value="0" name="draw_inside_polygon" type="QString"/>
+                  <Option value="bevel" name="joinstyle" type="QString"/>
+                  <Option value="35,35,35,255" name="line_color" type="QString"/>
+                  <Option value="solid" name="line_style" type="QString"/>
+                  <Option value="0.26" name="line_width" type="QString"/>
+                  <Option value="MM" name="line_width_unit" type="QString"/>
+                  <Option value="0" name="offset" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="offset_unit" type="QString"/>
+                  <Option value="0" name="ring_filter" type="QString"/>
+                  <Option value="0" name="trim_distance_end" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="trim_distance_end_unit" type="QString"/>
+                  <Option value="0" name="trim_distance_start" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale" type="QString"/>
+                  <Option value="MM" name="trim_distance_start_unit" type="QString"/>
+                  <Option value="0" name="tweak_dash_pattern_on_corners" type="QString"/>
+                  <Option value="0" name="use_custom_dash" type="QString"/>
+                  <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale" type="QString"/>
                 </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" value="" type="QString"/>
+                    <Option value="" name="name" type="QString"/>
                     <Option name="properties"/>
-                    <Option name="type" value="collection" type="QString"/>
+                    <Option value="collection" name="type" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -517,12 +545,12 @@
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings priority="0" dist="0" showAll="1" linePlacementFlags="18" obstacle="0" placement="0" zIndex="0">
+      <DiagramLayerSettings dist="0" placement="0" priority="0" linePlacementFlags="18" showAll="1" zIndex="0" obstacle="0">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
+            <Option value="" name="name" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" value="collection" type="QString"/>
+            <Option value="collection" name="type" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
@@ -549,34 +577,34 @@
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" field="id" index="0"/>
-        <alias name="" field="name" index="1"/>
+        <alias field="id" index="0" name=""/>
+        <alias field="name" index="1" name=""/>
       </aliases>
       <splitPolicies>
         <policy field="id" policy="Duplicate"/>
         <policy field="name" policy="Duplicate"/>
       </splitPolicies>
       <defaults>
-        <default field="id" applyOnUpdate="0" expression=""/>
-        <default field="name" applyOnUpdate="0" expression=""/>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint notnull_strength="0" field="id" unique_strength="0" constraints="0" exp_strength="0"/>
-        <constraint notnull_strength="0" field="name" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint field="id" notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0"/>
+        <constraint field="name" notnull_strength="0" exp_strength="0" unique_strength="0" constraints="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" field="id" exp=""/>
-        <constraint desc="" field="name" exp=""/>
+        <constraint field="id" exp="" desc=""/>
+        <constraint field="name" exp="" desc=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
         <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
       </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column name="id" hidden="0" type="field" width="-1"/>
-          <column name="name" hidden="0" type="field" width="-1"/>
-          <column hidden="1" type="actions" width="-1"/>
+          <column width="-1" hidden="0" name="id" type="field"/>
+          <column width="-1" hidden="0" name="name" type="field"/>
+          <column width="-1" hidden="1" type="actions"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -608,12 +636,12 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field name="id" editable="1"/>
-        <field name="name" editable="1"/>
+        <field editable="1" name="id"/>
+        <field editable="1" name="name"/>
       </editable>
       <labelOnTop>
-        <field name="id" labelOnTop="0"/>
-        <field name="name" labelOnTop="0"/>
+        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="name"/>
       </labelOnTop>
       <reuseLastValue>
         <field name="id" reuseLastValue="0"/>
@@ -626,7 +654,7 @@ def my_form_open(dialog, layer, feature):
     </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="points_e6681b07_b7aa_47ec_b13a_d4a69a9c0762"/>
+    <layer id="paris_c0ea3b6c_b829_486e_9622_f9fd5f725029"/>
   </layerorder>
   <properties>
     <Digitizing>
@@ -686,14 +714,19 @@ def my_form_open(dialog, layer, feature):
         <value>lizmap_user_groups</value>
       </variableNames>
       <variableValues type="QStringList">
-        <value>mapbuilder</value>
+        <value></value>
         <value></value>
         <value></value>
       </variableValues>
     </Variables>
     <WCSLayers type="QStringList"/>
     <WCSUrl type="QString"></WCSUrl>
-    <WFSLayers type="QStringList"/>
+    <WFSLayers type="QStringList">
+      <value>paris_c0ea3b6c_b829_486e_9622_f9fd5f725029</value>
+    </WFSLayers>
+    <WFSLayersPrecision>
+      <paris_c0ea3b6c_b829_486e_9622_f9fd5f725029 type="int">8</paris_c0ea3b6c_b829_486e_9622_f9fd5f725029>
+    </WFSLayersPrecision>
     <WFSTLayers>
       <Delete type="QStringList"/>
       <Insert type="QStringList"/>
@@ -708,29 +741,28 @@ def my_form_open(dialog, layer, feature):
     <WMSContactPerson type="QString"></WMSContactPerson>
     <WMSContactPhone type="QString"></WMSContactPhone>
     <WMSContactPosition type="QString"></WMSContactPosition>
-    <WMSDefaultMapUnitsPerMm type="double">1</WMSDefaultMapUnitsPerMm>
+    <WMSDefaultMapUnitsPerMm type="double">0</WMSDefaultMapUnitsPerMm>
     <WMSExtent type="QStringList">
-      <value>6.85292492800000019</value>
-      <value>60.60880866800000177</value>
-      <value>6.89807507200000014</value>
-      <value>60.635191331999998</value>
+      <value>193989.66209999998682179</value>
+      <value>6175778.14209999982267618</value>
+      <value>309960.01829999999608845</value>
+      <value>6278951.12750000040978193</value>
     </WMSExtent>
     <WMSFeatureInfoUseAttributeFormSettings type="bool">false</WMSFeatureInfoUseAttributeFormSettings>
     <WMSFees type="QString">conditions unknown</WMSFees>
     <WMSImageQuality type="int">90</WMSImageQuality>
     <WMSKeywordList type="QStringList">
-      <value>nord</value>
+      <value>france</value>
       <value>europe</value>
-      <value>dots</value>
     </WMSKeywordList>
     <WMSMaxAtlasFeatures type="int">1</WMSMaxAtlasFeatures>
     <WMSOnlineResource type="QString"></WMSOnlineResource>
     <WMSPrecision type="QString">8</WMSPrecision>
-    <WMSRootName type="QString">norwayPoints</WMSRootName>
+    <WMSRootName type="QString">Paris</WMSRootName>
     <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
     <WMSServiceAbstract type="QString"></WMSServiceAbstract>
     <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
-    <WMSServiceTitle type="QString">norwayPoints</WMSServiceTitle>
+    <WMSServiceTitle type="QString">Paris</WMSServiceTitle>
     <WMSTileBuffer type="int">0</WMSTileBuffer>
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
@@ -758,9 +790,9 @@ def my_form_open(dialog, layer, feature):
   </properties>
   <dataDefinedServerProperties>
     <Option type="Map">
-      <Option name="name" value="" type="QString"/>
+      <Option value="" name="name" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" value="collection" type="QString"/>
+      <Option value="collection" name="type" type="QString"/>
     </Option>
   </dataDefinedServerProperties>
   <visibility-presets/>
@@ -783,10 +815,10 @@ def my_form_open(dialog, layer, feature):
     </contact>
     <links/>
     <dates>
-      <date value="2025-02-25T11:04:02" type="Created"/>
+      <date value="2025-02-25T15:43:58" type="Created"/>
     </dates>
     <author>Neo</author>
-    <creation>2025-02-25T11:04:02</creation>
+    <creation>2025-02-25T15:43:58</creation>
   </projectMetadata>
   <Annotations/>
   <Layouts/>
@@ -795,7 +827,7 @@ def my_form_open(dialog, layer, feature):
   <Sensors/>
   <ProjectViewSettings UseProjectScales="0" rotation="0">
     <Scales/>
-    <DefaultViewExtent xmax="6.8970365229460926" ymin="60.6077697788325338" xmin="6.85362601013294626" ymax="60.63313592180352884">
+    <DefaultViewExtent xmin="2.19453088576312405" xmax="2.75954268533674929" ymax="49.03180232230970859" ymin="48.70164796200585755">
       <spatialrefsys nativeFormat="Wkt">
         <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
@@ -809,40 +841,40 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
-  <ProjectStyleSettings RandomizeDefaultSymbolColor="1" projectStyleId="attachment:///cHsVTb_styles.db" DefaultSymbolOpacity="1">
+  <ProjectStyleSettings RandomizeDefaultSymbolColor="1" projectStyleId="attachment:///GWVFsC_styles.db" DefaultSymbolOpacity="1">
     <databases/>
   </ProjectStyleSettings>
-  <ProjectTimeSettings timeStepUnit="h" cumulativeTemporalRange="0" frameRate="1" timeStep="1"/>
+  <ProjectTimeSettings timeStep="1" timeStepUnit="h" cumulativeTemporalRange="0" frameRate="1"/>
   <ElevationProperties>
     <terrainProvider type="flat">
       <TerrainProvider scale="1" offset="0"/>
     </terrainProvider>
   </ElevationProperties>
-  <ProjectDisplaySettings CoordinateType="MapCrs" CoordinateAxisOrder="Default">
+  <ProjectDisplaySettings CoordinateAxisOrder="Default" CoordinateType="MapCrs">
     <BearingFormat id="bearing">
       <Option type="Map">
         <Option name="decimal_separator" type="invalid"/>
-        <Option name="decimals" value="6" type="int"/>
-        <Option name="direction_format" value="0" type="int"/>
-        <Option name="rounding_type" value="0" type="int"/>
-        <Option name="show_plus" value="false" type="bool"/>
-        <Option name="show_thousand_separator" value="true" type="bool"/>
-        <Option name="show_trailing_zeros" value="false" type="bool"/>
+        <Option value="6" name="decimals" type="int"/>
+        <Option value="0" name="direction_format" type="int"/>
+        <Option value="0" name="rounding_type" type="int"/>
+        <Option value="false" name="show_plus" type="bool"/>
+        <Option value="true" name="show_thousand_separator" type="bool"/>
+        <Option value="false" name="show_trailing_zeros" type="bool"/>
         <Option name="thousand_separator" type="invalid"/>
       </Option>
     </BearingFormat>
     <GeographicCoordinateFormat id="geographiccoordinate">
       <Option type="Map">
-        <Option name="angle_format" value="DecimalDegrees" type="QString"/>
+        <Option value="DecimalDegrees" name="angle_format" type="QString"/>
         <Option name="decimal_separator" type="invalid"/>
-        <Option name="decimals" value="6" type="int"/>
-        <Option name="rounding_type" value="0" type="int"/>
-        <Option name="show_leading_degree_zeros" value="false" type="bool"/>
-        <Option name="show_leading_zeros" value="false" type="bool"/>
-        <Option name="show_plus" value="false" type="bool"/>
-        <Option name="show_suffix" value="false" type="bool"/>
-        <Option name="show_thousand_separator" value="true" type="bool"/>
-        <Option name="show_trailing_zeros" value="false" type="bool"/>
+        <Option value="6" name="decimals" type="int"/>
+        <Option value="0" name="rounding_type" type="int"/>
+        <Option value="false" name="show_leading_degree_zeros" type="bool"/>
+        <Option value="false" name="show_leading_zeros" type="bool"/>
+        <Option value="false" name="show_plus" type="bool"/>
+        <Option value="false" name="show_suffix" type="bool"/>
+        <Option value="true" name="show_thousand_separator" type="bool"/>
+        <Option value="false" name="show_trailing_zeros" type="bool"/>
         <Option name="thousand_separator" type="invalid"/>
       </Option>
     </GeographicCoordinateFormat>
@@ -860,7 +892,7 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings destinationLayer="points_e6681b07_b7aa_47ec_b13a_d4a69a9c0762" autoAddTrackVertices="0" destinationFollowsActiveLayer="1" destinationLayerProvider="ogr" destinationLayerName="points" autoCommitFeatures="0" destinationLayerSource="/home/neo/Documents/Alternance/lizmap-mapbuilder-module/tests/lizmap/instances/mapbuilder/points.geojson">
+  <ProjectGpsSettings destinationLayer="paris_c0ea3b6c_b829_486e_9622_f9fd5f725029" destinationFollowsActiveLayer="1" destinationLayerProvider="ogr" autoAddTrackVertices="0" destinationLayerSource="/home/neo/Documents/Alternance/lizmap-mapbuilder-module/tests/lizmap/instances/airportsTest/airportsParis.geojson" autoCommitFeatures="0" destinationLayerName="paris">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>

--- a/tests/lizmap/instances/airportsTest/Paris.qgs.cfg
+++ b/tests/lizmap/instances/airportsTest/Paris.qgs.cfg
@@ -1,0 +1,127 @@
+{
+    "metadata": {
+        "qgis_desktop_version": 33404,
+        "lizmap_plugin_version_str": "4.4.6",
+        "lizmap_plugin_version": 40406,
+        "lizmap_web_client_target_version": 30800,
+        "lizmap_web_client_target_status": "Stable",
+        "instance_target_url": "http://localhost:9016/"
+    },
+    "warnings": {},
+    "debug": {
+        "total_time": 0.085
+    },
+    "options": {
+        "projection": {
+            "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+            "ref": "EPSG:4326"
+        },
+        "bbox": [
+            "193989.66209999998682179",
+            "6175778.14209999982267618",
+            "309960.01829999999608845",
+            "6278951.12750000040978193"
+        ],
+        "mapScales": [
+            10000,
+            25000,
+            50000,
+            100000,
+            250000,
+            500000
+        ],
+        "minScale": 10000,
+        "maxScale": 500000,
+        "use_native_zoom_levels": false,
+        "hide_numeric_scale_value": false,
+        "initialExtent": [
+            6.854,
+            60.622,
+            6.897,
+            60.622
+        ],
+        "popupLocation": "dock",
+        "pointTolerance": 25,
+        "lineTolerance": 10,
+        "polygonTolerance": 5,
+        "automatic_permalink": true,
+        "tmTimeFrameSize": 10,
+        "tmTimeFrameType": "seconds",
+        "tmAnimationFrameLength": 1000,
+        "datavizLocation": "dock",
+        "theme": "dark",
+        "fixed_scale_overview_map": true,
+        "dataviz_drag_drop": []
+    },
+    "layers": {
+        "buildings": {
+            "id": "paris_c0ea3b6c_b829_486e_9622_f9fd5f725029",
+            "name": "buildings",
+            "type": "layer",
+            "geometryType": "point",
+            "extent": [
+                2.367736,
+                48.727683,
+                2.558098,
+                49.006742
+            ],
+            "crs": "EPSG:4326",
+            "title": "buildings",
+            "abstract": "",
+            "link": "",
+            "minScale": 1,
+            "maxScale": 1000000000000,
+            "toggled": "False",
+            "popup": "False",
+            "popupSource": "auto",
+            "popupTemplate": "",
+            "popupMaxFeatures": 10,
+            "popupDisplayChildren": "False",
+            "popup_allow_download": true,
+            "legend_image_option": "hide_at_startup",
+            "groupAsLayer": "False",
+            "baseLayer": "False",
+            "displayInLegend": "True",
+            "group_visibility": [],
+            "singleTile": "True",
+            "imageFormat": "image/png",
+            "cached": "False",
+            "clientCacheExpiration": 300
+        }
+    },
+    "atlas": {
+        "layers": []
+    },
+    "locateByLayer": {},
+    "attributeLayers": {
+        "buildings": {
+            "layerId": "paris_c0ea3b6c_b829_486e_9622_f9fd5f725029",
+            "primaryKey": "id",
+            "pivot": "False",
+            "hideAsChild": "False",
+            "hideLayer": "False",
+            "custom_config": "False",
+            "order": 0
+        }
+    },
+    "tooltipLayers": {},
+    "editionLayers": {},
+    "layouts": {
+        "config": {
+            "default_popup_print": false
+        },
+        "list": []
+    },
+    "loginFilteredLayers": {},
+    "timemanagerLayers": {},
+    "datavizLayers": {},
+    "filter_by_polygon": {
+        "config": {
+            "polygon_layer_id": null,
+            "group_field": "",
+            "filter_by_user": false
+        },
+        "layers": []
+    },
+    "formFilterLayers": {}
+}

--- a/tests/lizmap/instances/airportsTest/airportsParis.geojson
+++ b/tests/lizmap/instances/airportsTest/airportsParis.geojson
@@ -1,0 +1,8 @@
+{
+"type": "FeatureCollection",
+"name": "paris",
+"features": [ 
+{ "type": "Feature", "properties": { "id": 1, "name": "CDG" }, "geometry": { "type": "Point", "coordinates": [ 2.558098, 49.006742 ] } },
+{ "type": "Feature", "properties": { "id": 2, "name": "ORY" }, "geometry": { "type": "Point", "coordinates": [ 2.367736, 48.727683 ] } }
+]
+}

--- a/tests/lizmap/instances/mapbuilder/demo.qgs
+++ b/tests/lizmap/instances/mapbuilder/demo.qgs
@@ -1,12 +1,12 @@
-<qgis projectname="" saveDateTime="2022-09-19T11:03:52" saveUser="mdouchin" saveUserFull="mdouchin" version="3.22.8-Białowieża">
-  <homePath path=""></homePath>
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis saveUser="neo" saveUserFull="Neo" saveDateTime="2025-02-25T15:28:13" projectname="" version="3.34.4-Prizren">
+  <homePath path=""/>
   <title></title>
-  <autotransaction active="0"></autotransaction>
-  <evaluateDefaultValues active="0"></evaluateDefaultValues>
-  <trust active="0"></trust>
+  <transaction mode="Disabled"/>
+  <projectFlags set=""/>
   <projectCrs>
-    <spatialrefsys>
-      <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+    <spatialrefsys nativeFormat="Wkt">
+      <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
       <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
       <srsid>3452</srsid>
       <srid>4326</srid>
@@ -17,33 +17,34 @@
       <geographicflag>true</geographicflag>
     </spatialrefsys>
   </projectCrs>
+  <elevation-shading-renderer light-azimuth="315" edl-distance-unit="0" hillshading-is-active="0" edl-is-active="1" hillshading-is-multidirectional="0" hillshading-z-factor="1" edl-distance="0.5" edl-strength="1000" light-altitude="45" is-active="0" combined-method="0"/>
   <layer-tree-group>
     <customproperties>
-      <Option></Option>
+      <Option/>
     </customproperties>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9" legend_exp="" legend_split_behavior="0" name="trees" patch_size="-1,-1" providerKey="postgres" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;trees&quot; (geom)">
+    <layer-tree-layer expanded="1" legend_exp="" name="trees" checked="Qt::Checked" patch_size="-1,-1" legend_split_behavior="0" id="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;trees&quot; (geom)" providerKey="postgres">
       <customproperties>
-        <Option></Option>
+        <Option/>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="footways_50464328_c5b5_4f2b_9bd0_0e4994ec17d5" legend_exp="" legend_split_behavior="0" name="footways" patch_size="-1,-1" providerKey="postgres" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=LineString checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;footways&quot; (geom)">
+    <layer-tree-layer expanded="1" legend_exp="" name="footways" checked="Qt::Checked" patch_size="-1,-1" legend_split_behavior="0" id="footways_50464328_c5b5_4f2b_9bd0_0e4994ec17d5" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=LineString checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;footways&quot; (geom)" providerKey="postgres">
       <customproperties>
-        <Option></Option>
+        <Option/>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="water_surfaces_35b3563f_9a32_4576_b96e_1b455e15c1dd" legend_exp="" legend_split_behavior="0" name="water_surfaces" patch_size="-1,-1" providerKey="postgres" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;water_surfaces&quot; (geom)">
+    <layer-tree-layer expanded="1" legend_exp="" name="water_surfaces" checked="Qt::Checked" patch_size="-1,-1" legend_split_behavior="0" id="water_surfaces_35b3563f_9a32_4576_b96e_1b455e15c1dd" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;water_surfaces&quot; (geom)" providerKey="postgres">
       <customproperties>
-        <Option></Option>
+        <Option/>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="buildings_684162e1_2d79_4556_84ea_d58bab657395" legend_exp="" legend_split_behavior="0" name="buildings" patch_size="-1,-1" providerKey="postgres" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;buildings&quot; (geom)">
+    <layer-tree-layer expanded="1" legend_exp="" name="buildings" checked="Qt::Checked" patch_size="-1,-1" legend_split_behavior="0" id="buildings_684162e1_2d79_4556_84ea_d58bab657395" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;buildings&quot; (geom)" providerKey="postgres">
       <customproperties>
-        <Option></Option>
+        <Option/>
       </customproperties>
     </layer-tree-layer>
-    <layer-tree-layer checked="Qt::Checked" expanded="1" id="gardens_ea39c3a4_40ed_42cc_bfc6_6f9543cd7bec" legend_exp="" legend_split_behavior="0" name="gardens" patch_size="-1,-1" providerKey="postgres" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;gardens&quot; (geom)">
+    <layer-tree-layer expanded="1" legend_exp="" name="gardens" checked="Qt::Checked" patch_size="-1,-1" legend_split_behavior="0" id="gardens_ea39c3a4_40ed_42cc_bfc6_6f9543cd7bec" source="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;gardens&quot; (geom)" providerKey="postgres">
       <customproperties>
-        <Option></Option>
+        <Option/>
       </customproperties>
     </layer-tree-layer>
     <custom-order enabled="0">
@@ -54,18 +55,18 @@
       <item>buildings_684162e1_2d79_4556_84ea_d58bab657395</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings enabled="0" intersection-snapping="0" maxScale="0" minScale="0" mode="2" scaleDependencyMode="0" self-snapping="0" tolerance="12" type="1" unit="1">
+  <snapping-settings minScale="0" tolerance="12" maxScale="0" enabled="0" intersection-snapping="0" mode="2" type="1" unit="1" self-snapping="0" scaleDependencyMode="0">
     <individual-layer-settings>
-      <layer-setting enabled="0" id="gardens_ea39c3a4_40ed_42cc_bfc6_6f9543cd7bec" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
-      <layer-setting enabled="0" id="buildings_684162e1_2d79_4556_84ea_d58bab657395" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
-      <layer-setting enabled="0" id="footways_50464328_c5b5_4f2b_9bd0_0e4994ec17d5" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
-      <layer-setting enabled="0" id="water_surfaces_35b3563f_9a32_4576_b96e_1b455e15c1dd" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
-      <layer-setting enabled="0" id="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9" maxScale="0" minScale="0" tolerance="12" type="1" units="1"></layer-setting>
+      <layer-setting minScale="0" tolerance="12" maxScale="0" enabled="0" type="1" units="1" id="gardens_ea39c3a4_40ed_42cc_bfc6_6f9543cd7bec"/>
+      <layer-setting minScale="0" tolerance="12" maxScale="0" enabled="0" type="1" units="1" id="buildings_684162e1_2d79_4556_84ea_d58bab657395"/>
+      <layer-setting minScale="0" tolerance="12" maxScale="0" enabled="0" type="1" units="1" id="footways_50464328_c5b5_4f2b_9bd0_0e4994ec17d5"/>
+      <layer-setting minScale="0" tolerance="12" maxScale="0" enabled="0" type="1" units="1" id="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9"/>
+      <layer-setting minScale="0" tolerance="12" maxScale="0" enabled="0" type="1" units="1" id="water_surfaces_35b3563f_9a32_4576_b96e_1b455e15c1dd"/>
     </individual-layer-settings>
   </snapping-settings>
-  <relations></relations>
-  <polymorphicRelations></polymorphicRelations>
-  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+  <relations/>
+  <polymorphicRelations/>
+  <mapcanvas name="theMapCanvas" annotationsVisible="1">
     <units>degrees</units>
     <extent>
       <xmin>3.8665670972281756</xmin>
@@ -75,8 +76,8 @@
     </extent>
     <rotation>0</rotation>
     <destinationsrs>
-      <spatialrefsys>
-        <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -88,51 +89,38 @@
       </spatialrefsys>
     </destinationsrs>
     <rendermaptile>0</rendermaptile>
-    <expressionContextScope></expressionContextScope>
+    <expressionContextScope/>
   </mapcanvas>
-  <projectModels></projectModels>
+  <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="trees" open="true" showFeatureCount="0">
+    <legendlayer checked="Qt::Checked" name="trees" drawingOrder="-1" open="true" showFeatureCount="0">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9" visible="1"></legendlayerfile>
+        <legendlayerfile layerid="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="footways" open="true" showFeatureCount="0">
+    <legendlayer checked="Qt::Checked" name="footways" drawingOrder="-1" open="true" showFeatureCount="0">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="footways_50464328_c5b5_4f2b_9bd0_0e4994ec17d5" visible="1"></legendlayerfile>
+        <legendlayerfile layerid="footways_50464328_c5b5_4f2b_9bd0_0e4994ec17d5" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="water_surfaces" open="true" showFeatureCount="0">
+    <legendlayer checked="Qt::Checked" name="water_surfaces" drawingOrder="-1" open="true" showFeatureCount="0">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="water_surfaces_35b3563f_9a32_4576_b96e_1b455e15c1dd" visible="1"></legendlayerfile>
+        <legendlayerfile layerid="water_surfaces_35b3563f_9a32_4576_b96e_1b455e15c1dd" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="buildings" open="true" showFeatureCount="0">
+    <legendlayer checked="Qt::Checked" name="buildings" drawingOrder="-1" open="true" showFeatureCount="0">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="buildings_684162e1_2d79_4556_84ea_d58bab657395" visible="1"></legendlayerfile>
+        <legendlayerfile layerid="buildings_684162e1_2d79_4556_84ea_d58bab657395" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer checked="Qt::Checked" drawingOrder="-1" name="gardens" open="true" showFeatureCount="0">
+    <legendlayer checked="Qt::Checked" name="gardens" drawingOrder="-1" open="true" showFeatureCount="0">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="gardens_ea39c3a4_40ed_42cc_bfc6_6f9543cd7bec" visible="1"></legendlayerfile>
+        <legendlayerfile layerid="gardens_ea39c3a4_40ed_42cc_bfc6_6f9543cd7bec" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
   </legend>
-  <mapViewDocks></mapViewDocks>
-  <mapViewDocks3D></mapViewDocks3D>
-  <mapcanvas annotationsVisible="1" name="">
-    <units>unknown</units>
-    <extent>
-      <xmin>0</xmin>
-      <ymin>0</ymin>
-      <xmax>0</xmax>
-      <ymax>0</ymax>
-    </extent>
-    <rotation>0</rotation>
-    <rendermaptile>0</rendermaptile>
-    <expressionContextScope></expressionContextScope>
-  </mapcanvas>
-  <main-annotation-layer autoRefreshEnabled="0" autoRefreshTime="0" legendPlaceholderImage="" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="annotation">
+  <mapViewDocks/>
+  <main-annotation-layer minScale="0" refreshOnNotifyMessage="" autoRefreshMode="Disabled" styleCategories="AllStyleCategories" maxScale="0" autoRefreshTime="0" type="annotation" hasScaleBasedVisibilityFlag="0" refreshOnNotifyEnabled="0" legendPlaceholderImage="">
     <id>Annotations_49cb10be_cdd9_40b5_82b1_1198cb256ef3</id>
     <datasource></datasource>
     <keywordList>
@@ -140,7 +128,7 @@
     </keywordList>
     <layername>Annotations</layername>
     <srs>
-      <spatialrefsys>
+      <spatialrefsys nativeFormat="Wkt">
         <wkt></wkt>
         <proj4></proj4>
         <srsid>0</srsid>
@@ -159,11 +147,12 @@
       <type></type>
       <title></title>
       <abstract></abstract>
-      <links></links>
+      <links/>
+      <dates/>
       <fees></fees>
       <encoding></encoding>
       <crs>
-        <spatialrefsys>
+        <spatialrefsys nativeFormat="Wkt">
           <wkt></wkt>
           <proj4></proj4>
           <srsid>0</srsid>
@@ -175,15 +164,24 @@
           <geographicflag>false</geographicflag>
         </spatialrefsys>
       </crs>
-      <extent></extent>
+      <extent/>
     </resourceMetadata>
-    <items></items>
+    <items/>
+    <flags>
+      <Identifiable>1</Identifiable>
+      <Removable>1</Removable>
+      <Searchable>1</Searchable>
+      <Private>0</Private>
+    </flags>
+    <customproperties>
+      <Option/>
+    </customproperties>
     <layerOpacity>1</layerOpacity>
     <blendMode>0</blendMode>
-    <paintEffect></paintEffect>
+    <paintEffect/>
   </main-annotation-layer>
   <projectlayers>
-    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
+    <maplayer autoRefreshMode="Disabled" simplifyAlgorithm="0" minScale="100000000" simplifyLocal="1" legendPlaceholderImage="" readOnly="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" maxScale="0" autoRefreshTime="0" wkbType="MultiPolygon" simplifyMaxScale="1" geometry="Polygon" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" type="vector" simplifyDrawingTol="1" symbologyReferenceScale="-1" labelsEnabled="0">
       <extent>
         <xmin>3.86947774887085005</xmin>
         <ymin>43.61205291748046875</ymin>
@@ -203,8 +201,8 @@
       </keywordList>
       <layername>buildings</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -231,12 +229,13 @@
           <email></email>
           <role></role>
         </contact>
-        <links></links>
+        <links/>
+        <dates/>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
-            <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
             <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>3452</srsid>
             <srid>4326</srid>
@@ -248,7 +247,7 @@
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="EPSG:4326" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
+          <spatial minz="0" maxx="0" maxy="0" crs="EPSG:4326" minx="0" dimensions="2" miny="0" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -258,197 +257,283 @@
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins></vectorjoins>
-      <layerDependencies></layerDependencies>
-      <dataDependencies></dataDependencies>
-      <expressionfields></expressionfields>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"></map-layer-style>
+        <map-layer-style name="default"/>
       </map-layer-style-manager>
-      <auxiliaryLayer></auxiliaryLayer>
-      <metadataUrls></metadataUrls>
+      <auxiliaryLayer/>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+      <temporal startField="" accumulate="0" endField="" limitMode="0" durationUnit="min" enabled="0" fixedDuration="0" mode="0" durationField="" endExpression="" startExpression="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
-        <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+      <elevation zoffset="0" respectLayerSymbol="1" extrusion="0" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" type="IndividualFeatures" zscale="1" binding="Centroid" extrusionEnabled="0">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""></Option>
-                <Option name="properties"></Option>
-                <Option name="type" type="QString" value="collection"></Option>
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{e5e2fb09-333d-4ad9-8a05-d54ce6c806d7}">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="color" type="QString" value="200,200,200,255"></Option>
-                <Option name="joinstyle" type="QString" value="bevel"></Option>
-                <Option name="offset" type="QString" value="0,0"></Option>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="offset_unit" type="QString" value="MM"></Option>
-                <Option name="outline_color" type="QString" value="177,177,177,255"></Option>
-                <Option name="outline_style" type="QString" value="solid"></Option>
-                <Option name="outline_width" type="QString" value="0.26"></Option>
-                <Option name="outline_width_unit" type="QString" value="MM"></Option>
-                <Option name="style" type="QString" value="solid"></Option>
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="square" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="line_color" value="225,89,137,255" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.6" type="QString"/>
+                <Option name="line_width_unit" value="MM" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="color" v="200,200,200,255"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="offset" v="0,0"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="outline_color" v="177,177,177,255"></prop>
-              <prop k="outline_style" v="solid"></prop>
-              <prop k="outline_width" v="0.26"></prop>
-              <prop k="outline_width_unit" v="MM"></prop>
-              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
-            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="color" type="QString" value="177,177,177,255"></Option>
-                <Option name="joinstyle" type="QString" value="bevel"></Option>
-                <Option name="offset" type="QString" value="0,-0.59999999999999998"></Option>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="offset_unit" type="QString" value="MM"></Option>
-                <Option name="outline_color" type="QString" value="177,177,177,255"></Option>
-                <Option name="outline_style" type="QString" value="solid"></Option>
-                <Option name="outline_width" type="QString" value="0.26"></Option>
-                <Option name="outline_width_unit" type="QString" value="MM"></Option>
-                <Option name="style" type="QString" value="solid"></Option>
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="color" v="177,177,177,255"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="offset" v="0,-0.59999999999999998"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="outline_color" v="177,177,177,255"></prop>
-              <prop k="outline_style" v="solid"></prop>
-              <prop k="outline_width" v="0.26"></prop>
-              <prop k="outline_width_unit" v="MM"></prop>
-              <prop k="style" v="solid"></prop>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{cc640376-71ad-424e-8ea1-8b558b63311b}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="225,89,137,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="161,64,98,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{d2d6b68a-f083-4aae-afe4-a6c79a987373}">
+              <Option type="Map">
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="225,89,137,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="diamond" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="161,64,98,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="3" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MM" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
+        <symbols>
+          <symbol clip_to_extent="1" name="0" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{2e2aa848-67c3-4d59-91c7-8acf6fc6d404}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="200,200,200,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="177,177,177,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.26" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{4811e16e-dfe5-493e-b053-7cdc5449feac}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="177,177,177,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,-0.59999999999999998" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="177,177,177,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.26" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation></rotation>
-        <sizescale></sizescale>
+        <rotation/>
+        <sizescale/>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"/>
+      </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="OnConvertFormatRegeneratePrimaryKey" type="QString" value="false"></Option>
-          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
-          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
-          <Option name="variableNames" type="QString" value="quickosm_query"></Option>
-          <Option name="variableValues" type="QString" value="[out:xml] [timeout:25];&#xA;(&#xA;    node[&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    node[&quot;type&quot;=&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;type&quot;=&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;type&quot;=&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;);&#xA;(._;>;);&#xA;out body;"></Option>
+          <Option name="OnConvertFormatRegeneratePrimaryKey" value="false" type="QString"/>
+          <Option name="QFieldSync/action" value="offline" type="QString"/>
+          <Option name="QFieldSync/cloud_action" value="offline" type="QString"/>
+          <Option name="QFieldSync/photo_naming" value="{}" type="QString"/>
+          <Option name="embeddedWidgets/count" value="0" type="QString"/>
+          <Option name="variableNames" value="quickosm_query" type="QString"/>
+          <Option name="variableValues" value="[out:xml] [timeout:25];&#xa;(&#xa;    node[&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    node[&quot;type&quot;=&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;type&quot;=&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;type&quot;=&quot;building&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;);&#xa;(._;>;);&#xa;out body;" type="QString"/>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="0" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="1" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="5" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
-          <attribute color="#000000" field="" label=""></attribute>
+        <DiagramCategory scaleDependency="Area" sizeType="MM" spacingUnit="MM" direction="0" height="15" rotationOffset="270" barWidth="5" scaleBasedVisibility="0" penColor="#000000" minimumSize="0" spacingUnitScale="3x:0,0,0,0,0,0" backgroundAlpha="255" showAxis="1" opacity="1" minScaleDenominator="0" penAlpha="255" width="15" enabled="0" penWidth="0" diagramOrientation="Up" spacing="5" lineSizeType="MM" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" backgroundColor="#ffffff" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0">
+          <fontProperties bold="0" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" underline="0" style="" strikethrough="0"/>
+          <attribute field="" color="#000000" label="" colorOpacity="1"/>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+            <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{32ff75fe-bccb-4cfc-a53b-4b5502f89c0e}">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
-                  <Option name="capstyle" type="QString" value="square"></Option>
-                  <Option name="customdash" type="QString" value="5;2"></Option>
-                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="customdash_unit" type="QString" value="MM"></Option>
-                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
-                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
-                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
-                  <Option name="joinstyle" type="QString" value="bevel"></Option>
-                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
-                  <Option name="line_style" type="QString" value="solid"></Option>
-                  <Option name="line_width" type="QString" value="0.26"></Option>
-                  <Option name="line_width_unit" type="QString" value="MM"></Option>
-                  <Option name="offset" type="QString" value="0"></Option>
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="offset_unit" type="QString" value="MM"></Option>
-                  <Option name="ring_filter" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
-                  <Option name="trim_distance_start" type="QString" value="0"></Option>
-                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
-                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
-                  <Option name="use_custom_dash" type="QString" value="0"></Option>
-                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="align_dash_pattern" value="0" type="QString"/>
+                  <Option name="capstyle" value="square" type="QString"/>
+                  <Option name="customdash" value="5;2" type="QString"/>
+                  <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="customdash_unit" value="MM" type="QString"/>
+                  <Option name="dash_pattern_offset" value="0" type="QString"/>
+                  <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                  <Option name="draw_inside_polygon" value="0" type="QString"/>
+                  <Option name="joinstyle" value="bevel" type="QString"/>
+                  <Option name="line_color" value="35,35,35,255" type="QString"/>
+                  <Option name="line_style" value="solid" type="QString"/>
+                  <Option name="line_width" value="0.26" type="QString"/>
+                  <Option name="line_width_unit" value="MM" type="QString"/>
+                  <Option name="offset" value="0" type="QString"/>
+                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="offset_unit" value="MM" type="QString"/>
+                  <Option name="ring_filter" value="0" type="QString"/>
+                  <Option name="trim_distance_end" value="0" type="QString"/>
+                  <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                  <Option name="trim_distance_start" value="0" type="QString"/>
+                  <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                  <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                  <Option name="use_custom_dash" value="0" type="QString"/>
+                  <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
                 </Option>
-                <prop k="align_dash_pattern" v="0"></prop>
-                <prop k="capstyle" v="square"></prop>
-                <prop k="customdash" v="5;2"></prop>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="customdash_unit" v="MM"></prop>
-                <prop k="dash_pattern_offset" v="0"></prop>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="dash_pattern_offset_unit" v="MM"></prop>
-                <prop k="draw_inside_polygon" v="0"></prop>
-                <prop k="joinstyle" v="bevel"></prop>
-                <prop k="line_color" v="35,35,35,255"></prop>
-                <prop k="line_style" v="solid"></prop>
-                <prop k="line_width" v="0.26"></prop>
-                <prop k="line_width_unit" v="MM"></prop>
-                <prop k="offset" v="0"></prop>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="offset_unit" v="MM"></prop>
-                <prop k="ring_filter" v="0"></prop>
-                <prop k="trim_distance_end" v="0"></prop>
-                <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_end_unit" v="MM"></prop>
-                <prop k="trim_distance_start" v="0"></prop>
-                <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_start_unit" v="MM"></prop>
-                <prop k="tweak_dash_pattern_on_corners" v="0"></prop>
-                <prop k="use_custom_dash" v="0"></prop>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value=""></Option>
-                    <Option name="properties"></Option>
-                    <Option name="type" type="QString" value="collection"></Option>
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -456,197 +541,208 @@
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
+      <DiagramLayerSettings priority="0" dist="0" showAll="1" linePlacementFlags="18" obstacle="0" placement="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""></Option>
-            <Option name="properties"></Option>
-            <Option name="type" type="QString" value="collection"></Option>
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks></activeChecks>
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+        <activeChecks/>
         <checkConfiguration type="Map">
           <Option name="QgsGeometryGapCheck" type="Map">
-            <Option name="allowedGapsBuffer" type="double" value="0"></Option>
-            <Option name="allowedGapsEnabled" type="bool" value="false"></Option>
-            <Option name="allowedGapsLayer" type="QString" value=""></Option>
+            <Option name="allowedGapsBuffer" value="0" type="double"/>
+            <Option name="allowedGapsEnabled" value="false" type="bool"/>
+            <Option name="allowedGapsLayer" value="" type="QString"/>
           </Option>
         </checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"></legend>
-      <referencedLayers></referencedLayers>
+      <legend showLabelLegend="0" type="default-vector"/>
+      <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="full_id">
+        <field configurationFlags="NoFlag" name="full_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_id">
+        <field configurationFlags="NoFlag" name="osm_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_type">
+        <field configurationFlags="NoFlag" name="osm_type">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="building">
+        <field configurationFlags="NoFlag" name="building">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="name">
+        <field configurationFlags="NoFlag" name="name">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="amenity">
+        <field configurationFlags="NoFlag" name="amenity">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="wikipedia">
+        <field configurationFlags="NoFlag" name="wikipedia">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="height">
+        <field configurationFlags="NoFlag" name="height">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""></alias>
-        <alias field="full_id" index="1" name=""></alias>
-        <alias field="osm_id" index="2" name=""></alias>
-        <alias field="osm_type" index="3" name=""></alias>
-        <alias field="building" index="4" name=""></alias>
-        <alias field="name" index="5" name=""></alias>
-        <alias field="amenity" index="6" name=""></alias>
-        <alias field="wikipedia" index="7" name=""></alias>
-        <alias field="height" index="8" name=""></alias>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="full_id" index="1"/>
+        <alias name="" field="osm_id" index="2"/>
+        <alias name="" field="osm_type" index="3"/>
+        <alias name="" field="building" index="4"/>
+        <alias name="" field="name" index="5"/>
+        <alias name="" field="amenity" index="6"/>
+        <alias name="" field="wikipedia" index="7"/>
+        <alias name="" field="height" index="8"/>
       </aliases>
+      <splitPolicies>
+        <policy field="id" policy="Duplicate"/>
+        <policy field="full_id" policy="Duplicate"/>
+        <policy field="osm_id" policy="Duplicate"/>
+        <policy field="osm_type" policy="Duplicate"/>
+        <policy field="building" policy="Duplicate"/>
+        <policy field="name" policy="Duplicate"/>
+        <policy field="amenity" policy="Duplicate"/>
+        <policy field="wikipedia" policy="Duplicate"/>
+        <policy field="height" policy="Duplicate"/>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="id"></default>
-        <default applyOnUpdate="0" expression="" field="full_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_type"></default>
-        <default applyOnUpdate="0" expression="" field="building"></default>
-        <default applyOnUpdate="0" expression="" field="name"></default>
-        <default applyOnUpdate="0" expression="" field="amenity"></default>
-        <default applyOnUpdate="0" expression="" field="wikipedia"></default>
-        <default applyOnUpdate="0" expression="" field="height"></default>
+        <default field="id" applyOnUpdate="0" expression=""/>
+        <default field="full_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_type" applyOnUpdate="0" expression=""/>
+        <default field="building" applyOnUpdate="0" expression=""/>
+        <default field="name" applyOnUpdate="0" expression=""/>
+        <default field="amenity" applyOnUpdate="0" expression=""/>
+        <default field="wikipedia" applyOnUpdate="0" expression=""/>
+        <default field="height" applyOnUpdate="0" expression=""/>
       </defaults>
       <constraints>
-        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
-        <constraint constraints="0" exp_strength="0" field="full_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_type" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="building" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="amenity" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="wikipedia" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="height" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint notnull_strength="1" field="id" unique_strength="1" constraints="3" exp_strength="0"/>
+        <constraint notnull_strength="0" field="full_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_type" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="building" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="name" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="amenity" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="wikipedia" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="height" unique_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"></constraint>
-        <constraint desc="" exp="" field="full_id"></constraint>
-        <constraint desc="" exp="" field="osm_id"></constraint>
-        <constraint desc="" exp="" field="osm_type"></constraint>
-        <constraint desc="" exp="" field="building"></constraint>
-        <constraint desc="" exp="" field="name"></constraint>
-        <constraint desc="" exp="" field="amenity"></constraint>
-        <constraint desc="" exp="" field="wikipedia"></constraint>
-        <constraint desc="" exp="" field="height"></constraint>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="full_id" exp=""/>
+        <constraint desc="" field="osm_id" exp=""/>
+        <constraint desc="" field="osm_type" exp=""/>
+        <constraint desc="" field="building" exp=""/>
+        <constraint desc="" field="name" exp=""/>
+        <constraint desc="" field="amenity" exp=""/>
+        <constraint desc="" field="wikipedia" exp=""/>
+        <constraint desc="" field="height" exp=""/>
       </constraintExpressions>
-      <expressionfields></expressionfields>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
-        <actionsetting action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" capture="0" icon="" id="{34f4fa06-bbff-4e7a-a0f1-cb0a01b1f2e6}" isEnabledOnlyWhenEditable="0" name="OpenStreetMap Browser" notificationMessage="" shortTitle="OpenStreetMap Browser" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <actionsetting notificationMessage="" name="OpenStreetMap Browser" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" shortTitle="OpenStreetMap Browser" icon="" id="{34f4fa06-bbff-4e7a-a0f1-cb0a01b1f2e6}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{081fc55c-6215-4087-b190-bedb9f1f4c5a}" isEnabledOnlyWhenEditable="0" name="JOSM" notificationMessage="" shortTitle="JOSM" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="JOSM" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" shortTitle="JOSM" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{081fc55c-6215-4087-b190-bedb9f1f4c5a}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" capture="0" icon="" id="{54b0e22b-ea14-46c6-9d4a-c020ac2ff009}" isEnabledOnlyWhenEditable="0" name="User default editor" notificationMessage="" shortTitle="User default editor" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="User default editor" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" shortTitle="User default editor" icon="" id="{54b0e22b-ea14-46c6-9d4a-c020ac2ff009}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;wikipedia&quot;,&quot;[% &quot;wikipedia&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/wikipedia.png" id="{cac4c36b-44ce-47c6-b168-cd60ede22f80}" isEnabledOnlyWhenEditable="0" name="wikipedia" notificationMessage="" shortTitle="wikipedia" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="wikipedia" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;wikipedia&quot;,&quot;[% &quot;wikipedia&quot; %]&quot;)" shortTitle="wikipedia" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/wikipedia.png" id="{cac4c36b-44ce-47c6-b168-cd60ede22f80}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;wikidata&quot;,&quot;[% &quot;wikidata&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/wikidata.png" id="{c61bbb8a-7d9b-4aaa-a99c-b9b735c218f8}" isEnabledOnlyWhenEditable="0" name="wikidata" notificationMessage="" shortTitle="wikidata" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="wikidata" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;wikidata&quot;,&quot;[% &quot;wikidata&quot; %]&quot;)" shortTitle="wikidata" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/wikidata.png" id="{c61bbb8a-7d9b-4aaa-a99c-b9b735c218f8}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;ref_UAI&quot;,&quot;[% &quot;ref_UAI&quot; %]&quot;)" capture="0" icon="" id="{26e8ed60-f45d-44a2-9322-45bfc33d7f3f}" isEnabledOnlyWhenEditable="0" name="ref_UAI" notificationMessage="" shortTitle="ref_UAI" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="ref_UAI" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;ref_UAI&quot;,&quot;[% &quot;ref_UAI&quot; %]&quot;)" shortTitle="ref_UAI" icon="" id="{26e8ed60-f45d-44a2-9322-45bfc33d7f3f}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Buildings&quot;)" capture="0" icon="" id="{48c170e1-fe82-4818-b112-568235accd55}" isEnabledOnlyWhenEditable="0" name="Reload the query in a new file" notificationMessage="" shortTitle="Reload the query in a new file" type="1">
-          <actionScope id="Layer"></actionScope>
+        <actionsetting notificationMessage="" name="Reload the query in a new file" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Buildings&quot;)" shortTitle="Reload the query in a new file" icon="" id="{48c170e1-fe82-4818-b112-568235accd55}">
+          <actionScope id="Layer"/>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
         <columns>
-          <column hidden="0" name="full_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_type" type="field" width="-1"></column>
-          <column hidden="0" name="building" type="field" width="-1"></column>
-          <column hidden="0" name="wikipedia" type="field" width="-1"></column>
-          <column hidden="0" name="name" type="field" width="-1"></column>
-          <column hidden="0" name="height" type="field" width="-1"></column>
-          <column hidden="0" name="amenity" type="field" width="-1"></column>
-          <column hidden="1" type="actions" width="-1"></column>
-          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column name="full_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_type" hidden="0" type="field" width="-1"/>
+          <column name="building" hidden="0" type="field" width="-1"/>
+          <column name="wikipedia" hidden="0" type="field" width="-1"/>
+          <column name="name" hidden="0" type="field" width="-1"/>
+          <column name="height" hidden="0" type="field" width="-1"/>
+          <column name="amenity" hidden="0" type="field" width="-1"/>
+          <column hidden="1" type="actions" width="-1"/>
+          <column name="id" hidden="0" type="field" width="-1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles></rowstyles>
-        <fieldstyles></fieldstyles>
+        <rowstyles/>
+        <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions></storedexpressions>
+      <storedexpressions/>
       <editform tolerant="1"></editform>
-      <editforminit></editforminit>
+      <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode># -*- coding: utf-8 -*-
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -662,94 +758,94 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-</editforminitcode>
+]]></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="addr:city"></field>
-        <field editable="1" name="addr:housenumber"></field>
-        <field editable="1" name="addr:postcode"></field>
-        <field editable="1" name="addr:street"></field>
-        <field editable="1" name="alt_name"></field>
-        <field editable="1" name="amenity"></field>
-        <field editable="1" name="basilica"></field>
-        <field editable="1" name="building"></field>
-        <field editable="1" name="building:part"></field>
-        <field editable="1" name="denomination"></field>
-        <field editable="1" name="description"></field>
-        <field editable="1" name="full_id"></field>
-        <field editable="1" name="height"></field>
-        <field editable="1" name="heritage"></field>
-        <field editable="1" name="heritage:operator"></field>
-        <field editable="1" name="historic"></field>
-        <field editable="1" name="id"></field>
-        <field editable="1" name="landuse"></field>
-        <field editable="1" name="layer"></field>
-        <field editable="1" name="man_made"></field>
-        <field editable="1" name="mhs:inscription_date"></field>
-        <field editable="1" name="military"></field>
-        <field editable="1" name="name"></field>
-        <field editable="1" name="opening_hours"></field>
-        <field editable="1" name="operator"></field>
-        <field editable="1" name="osm_id"></field>
-        <field editable="1" name="osm_type"></field>
-        <field editable="1" name="ref:UAI"></field>
-        <field editable="1" name="ref:mhs"></field>
-        <field editable="1" name="religion"></field>
-        <field editable="1" name="source:heritage"></field>
-        <field editable="1" name="tower:type"></field>
-        <field editable="1" name="type"></field>
-        <field editable="1" name="wall"></field>
-        <field editable="1" name="wheelchair"></field>
-        <field editable="1" name="wikidata"></field>
-        <field editable="1" name="wikipedia"></field>
+        <field name="addr:city" editable="1"/>
+        <field name="addr:housenumber" editable="1"/>
+        <field name="addr:postcode" editable="1"/>
+        <field name="addr:street" editable="1"/>
+        <field name="alt_name" editable="1"/>
+        <field name="amenity" editable="1"/>
+        <field name="basilica" editable="1"/>
+        <field name="building" editable="1"/>
+        <field name="building:part" editable="1"/>
+        <field name="denomination" editable="1"/>
+        <field name="description" editable="1"/>
+        <field name="full_id" editable="1"/>
+        <field name="height" editable="1"/>
+        <field name="heritage" editable="1"/>
+        <field name="heritage:operator" editable="1"/>
+        <field name="historic" editable="1"/>
+        <field name="id" editable="1"/>
+        <field name="landuse" editable="1"/>
+        <field name="layer" editable="1"/>
+        <field name="man_made" editable="1"/>
+        <field name="mhs:inscription_date" editable="1"/>
+        <field name="military" editable="1"/>
+        <field name="name" editable="1"/>
+        <field name="opening_hours" editable="1"/>
+        <field name="operator" editable="1"/>
+        <field name="osm_id" editable="1"/>
+        <field name="osm_type" editable="1"/>
+        <field name="ref:UAI" editable="1"/>
+        <field name="ref:mhs" editable="1"/>
+        <field name="religion" editable="1"/>
+        <field name="source:heritage" editable="1"/>
+        <field name="tower:type" editable="1"/>
+        <field name="type" editable="1"/>
+        <field name="wall" editable="1"/>
+        <field name="wheelchair" editable="1"/>
+        <field name="wikidata" editable="1"/>
+        <field name="wikipedia" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="addr:city"></field>
-        <field labelOnTop="0" name="addr:housenumber"></field>
-        <field labelOnTop="0" name="addr:postcode"></field>
-        <field labelOnTop="0" name="addr:street"></field>
-        <field labelOnTop="0" name="alt_name"></field>
-        <field labelOnTop="0" name="amenity"></field>
-        <field labelOnTop="0" name="basilica"></field>
-        <field labelOnTop="0" name="building"></field>
-        <field labelOnTop="0" name="building:part"></field>
-        <field labelOnTop="0" name="denomination"></field>
-        <field labelOnTop="0" name="description"></field>
-        <field labelOnTop="0" name="full_id"></field>
-        <field labelOnTop="0" name="height"></field>
-        <field labelOnTop="0" name="heritage"></field>
-        <field labelOnTop="0" name="heritage:operator"></field>
-        <field labelOnTop="0" name="historic"></field>
-        <field labelOnTop="0" name="id"></field>
-        <field labelOnTop="0" name="landuse"></field>
-        <field labelOnTop="0" name="layer"></field>
-        <field labelOnTop="0" name="man_made"></field>
-        <field labelOnTop="0" name="mhs:inscription_date"></field>
-        <field labelOnTop="0" name="military"></field>
-        <field labelOnTop="0" name="name"></field>
-        <field labelOnTop="0" name="opening_hours"></field>
-        <field labelOnTop="0" name="operator"></field>
-        <field labelOnTop="0" name="osm_id"></field>
-        <field labelOnTop="0" name="osm_type"></field>
-        <field labelOnTop="0" name="ref:UAI"></field>
-        <field labelOnTop="0" name="ref:mhs"></field>
-        <field labelOnTop="0" name="religion"></field>
-        <field labelOnTop="0" name="source:heritage"></field>
-        <field labelOnTop="0" name="tower:type"></field>
-        <field labelOnTop="0" name="type"></field>
-        <field labelOnTop="0" name="wall"></field>
-        <field labelOnTop="0" name="wheelchair"></field>
-        <field labelOnTop="0" name="wikidata"></field>
-        <field labelOnTop="0" name="wikipedia"></field>
+        <field name="addr:city" labelOnTop="0"/>
+        <field name="addr:housenumber" labelOnTop="0"/>
+        <field name="addr:postcode" labelOnTop="0"/>
+        <field name="addr:street" labelOnTop="0"/>
+        <field name="alt_name" labelOnTop="0"/>
+        <field name="amenity" labelOnTop="0"/>
+        <field name="basilica" labelOnTop="0"/>
+        <field name="building" labelOnTop="0"/>
+        <field name="building:part" labelOnTop="0"/>
+        <field name="denomination" labelOnTop="0"/>
+        <field name="description" labelOnTop="0"/>
+        <field name="full_id" labelOnTop="0"/>
+        <field name="height" labelOnTop="0"/>
+        <field name="heritage" labelOnTop="0"/>
+        <field name="heritage:operator" labelOnTop="0"/>
+        <field name="historic" labelOnTop="0"/>
+        <field name="id" labelOnTop="0"/>
+        <field name="landuse" labelOnTop="0"/>
+        <field name="layer" labelOnTop="0"/>
+        <field name="man_made" labelOnTop="0"/>
+        <field name="mhs:inscription_date" labelOnTop="0"/>
+        <field name="military" labelOnTop="0"/>
+        <field name="name" labelOnTop="0"/>
+        <field name="opening_hours" labelOnTop="0"/>
+        <field name="operator" labelOnTop="0"/>
+        <field name="osm_id" labelOnTop="0"/>
+        <field name="osm_type" labelOnTop="0"/>
+        <field name="ref:UAI" labelOnTop="0"/>
+        <field name="ref:mhs" labelOnTop="0"/>
+        <field name="religion" labelOnTop="0"/>
+        <field name="source:heritage" labelOnTop="0"/>
+        <field name="tower:type" labelOnTop="0"/>
+        <field name="type" labelOnTop="0"/>
+        <field name="wall" labelOnTop="0"/>
+        <field name="wheelchair" labelOnTop="0"/>
+        <field name="wikidata" labelOnTop="0"/>
+        <field name="wikipedia" labelOnTop="0"/>
       </labelOnTop>
-      <reuseLastValue></reuseLastValue>
-      <dataDefinedFieldProperties></dataDefinedFieldProperties>
-      <widgets></widgets>
+      <reuseLastValue/>
+      <dataDefinedFieldProperties/>
+      <widgets/>
       <previewExpression>"alt_name"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Line" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="LineString">
+    <maplayer autoRefreshMode="Disabled" simplifyAlgorithm="0" minScale="100000000" simplifyLocal="1" legendPlaceholderImage="" readOnly="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" maxScale="0" autoRefreshTime="0" wkbType="LineString" simplifyMaxScale="1" geometry="Line" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" type="vector" simplifyDrawingTol="1" symbologyReferenceScale="-1" labelsEnabled="0">
       <extent>
         <xmin>3.86956477165222212</xmin>
         <ymin>43.61226272583007813</ymin>
@@ -769,8 +865,8 @@ def my_form_open(dialog, layer, feature):
       </keywordList>
       <layername>footways</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -797,12 +893,13 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links></links>
+        <links/>
+        <dates/>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
-            <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
             <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>3452</srsid>
             <srid>4326</srid>
@@ -814,7 +911,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="EPSG:4326" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
+          <spatial minz="0" maxx="0" maxy="0" crs="EPSG:4326" minx="0" dimensions="2" miny="0" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -824,196 +921,277 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins></vectorjoins>
-      <layerDependencies></layerDependencies>
-      <dataDependencies></dataDependencies>
-      <expressionfields></expressionfields>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"></map-layer-style>
+        <map-layer-style name="default"/>
       </map-layer-style-manager>
-      <auxiliaryLayer></auxiliaryLayer>
-      <metadataUrls></metadataUrls>
+      <auxiliaryLayer/>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+      <temporal startField="" accumulate="0" endField="" limitMode="0" durationUnit="min" enabled="0" fixedDuration="0" mode="0" durationField="" endExpression="" startExpression="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
-        <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="line">
+      <elevation zoffset="0" respectLayerSymbol="1" extrusion="0" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" type="IndividualFeatures" zscale="1" binding="Centroid" extrusionEnabled="0">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""></Option>
-                <Option name="properties"></Option>
-                <Option name="type" type="QString" value="collection"></Option>
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{f3c19e4f-ed8c-4164-b646-3d5f1ea2f9e3}">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0"></Option>
-                <Option name="capstyle" type="QString" value="square"></Option>
-                <Option name="customdash" type="QString" value="5;2"></Option>
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="customdash_unit" type="QString" value="MM"></Option>
-                <Option name="dash_pattern_offset" type="QString" value="0"></Option>
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
-                <Option name="draw_inside_polygon" type="QString" value="0"></Option>
-                <Option name="joinstyle" type="QString" value="bevel"></Option>
-                <Option name="line_color" type="QString" value="127,99,30,255"></Option>
-                <Option name="line_style" type="QString" value="dash"></Option>
-                <Option name="line_width" type="QString" value="0.3"></Option>
-                <Option name="line_width_unit" type="QString" value="MM"></Option>
-                <Option name="offset" type="QString" value="0"></Option>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="offset_unit" type="QString" value="MM"></Option>
-                <Option name="ring_filter" type="QString" value="0"></Option>
-                <Option name="trim_distance_end" type="QString" value="0"></Option>
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
-                <Option name="trim_distance_start" type="QString" value="0"></Option>
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
-                <Option name="use_custom_dash" type="QString" value="0"></Option>
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="square" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="line_color" value="229,182,54,255" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.6" type="QString"/>
+                <Option name="line_width_unit" value="MM" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop k="align_dash_pattern" v="0"></prop>
-              <prop k="capstyle" v="square"></prop>
-              <prop k="customdash" v="5;2"></prop>
-              <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="customdash_unit" v="MM"></prop>
-              <prop k="dash_pattern_offset" v="0"></prop>
-              <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="dash_pattern_offset_unit" v="MM"></prop>
-              <prop k="draw_inside_polygon" v="0"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="line_color" v="127,99,30,255"></prop>
-              <prop k="line_style" v="dash"></prop>
-              <prop k="line_width" v="0.3"></prop>
-              <prop k="line_width_unit" v="MM"></prop>
-              <prop k="offset" v="0"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="ring_filter" v="0"></prop>
-              <prop k="trim_distance_end" v="0"></prop>
-              <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="trim_distance_end_unit" v="MM"></prop>
-              <prop k="trim_distance_start" v="0"></prop>
-              <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="trim_distance_start_unit" v="MM"></prop>
-              <prop k="tweak_dash_pattern_on_corners" v="0"></prop>
-              <prop k="use_custom_dash" v="0"></prop>
-              <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{33bfd536-8231-45c9-802e-1680633fb3d8}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="229,182,54,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="164,130,39,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{626b8118-8f70-48ef-b50f-23997c3b63f0}">
+              <Option type="Map">
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="229,182,54,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="diamond" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="164,130,39,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="3" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MM" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
+        <symbols>
+          <symbol clip_to_extent="1" name="0" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{131c5a64-f114-488a-a9dd-334b390f7cb6}">
+              <Option type="Map">
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="square" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="line_color" value="127,99,30,255" type="QString"/>
+                <Option name="line_style" value="dash" type="QString"/>
+                <Option name="line_width" value="0.3" type="QString"/>
+                <Option name="line_width_unit" value="MM" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation></rotation>
-        <sizescale></sizescale>
+        <rotation/>
+        <sizescale/>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"/>
+      </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="OnConvertFormatRegeneratePrimaryKey" type="QString" value="false"></Option>
-          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
-          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
-          <Option name="variableNames" type="QString" value="quickosm_query"></Option>
-          <Option name="variableValues" type="QString" value="[out:xml] [timeout:25];&#xA;(&#xA;    node[&quot;highway&quot;=&quot;track&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    node[&quot;highway&quot;=&quot;footway&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    node[&quot;highway&quot;=&quot;path&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;highway&quot;=&quot;track&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;highway&quot;=&quot;footway&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;highway&quot;=&quot;path&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;highway&quot;=&quot;track&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;highway&quot;=&quot;footway&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;highway&quot;=&quot;path&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;);&#xA;(._;>;);&#xA;out body;"></Option>
+          <Option name="OnConvertFormatRegeneratePrimaryKey" value="false" type="QString"/>
+          <Option name="QFieldSync/action" value="offline" type="QString"/>
+          <Option name="QFieldSync/cloud_action" value="offline" type="QString"/>
+          <Option name="QFieldSync/photo_naming" value="{}" type="QString"/>
+          <Option name="embeddedWidgets/count" value="0" type="QString"/>
+          <Option name="variableNames" value="quickosm_query" type="QString"/>
+          <Option name="variableValues" value="[out:xml] [timeout:25];&#xa;(&#xa;    node[&quot;highway&quot;=&quot;track&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    node[&quot;highway&quot;=&quot;footway&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    node[&quot;highway&quot;=&quot;path&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;highway&quot;=&quot;track&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;highway&quot;=&quot;footway&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;highway&quot;=&quot;path&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;highway&quot;=&quot;track&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;highway&quot;=&quot;footway&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;highway&quot;=&quot;path&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;);&#xa;(._;>;);&#xa;out body;" type="QString"/>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="0" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="1" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="5" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
-          <attribute color="#000000" field="" label=""></attribute>
+        <DiagramCategory scaleDependency="Area" sizeType="MM" spacingUnit="MM" direction="0" height="15" rotationOffset="270" barWidth="5" scaleBasedVisibility="0" penColor="#000000" minimumSize="0" spacingUnitScale="3x:0,0,0,0,0,0" backgroundAlpha="255" showAxis="1" opacity="1" minScaleDenominator="0" penAlpha="255" width="15" enabled="0" penWidth="0" diagramOrientation="Up" spacing="5" lineSizeType="MM" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" backgroundColor="#ffffff" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0">
+          <fontProperties bold="0" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" underline="0" style="" strikethrough="0"/>
+          <attribute field="" color="#000000" label="" colorOpacity="1"/>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+            <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{c8dd504e-ef2c-4f58-9a03-16b51bc19b68}">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
-                  <Option name="capstyle" type="QString" value="square"></Option>
-                  <Option name="customdash" type="QString" value="5;2"></Option>
-                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="customdash_unit" type="QString" value="MM"></Option>
-                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
-                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
-                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
-                  <Option name="joinstyle" type="QString" value="bevel"></Option>
-                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
-                  <Option name="line_style" type="QString" value="solid"></Option>
-                  <Option name="line_width" type="QString" value="0.26"></Option>
-                  <Option name="line_width_unit" type="QString" value="MM"></Option>
-                  <Option name="offset" type="QString" value="0"></Option>
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="offset_unit" type="QString" value="MM"></Option>
-                  <Option name="ring_filter" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
-                  <Option name="trim_distance_start" type="QString" value="0"></Option>
-                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
-                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
-                  <Option name="use_custom_dash" type="QString" value="0"></Option>
-                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="align_dash_pattern" value="0" type="QString"/>
+                  <Option name="capstyle" value="square" type="QString"/>
+                  <Option name="customdash" value="5;2" type="QString"/>
+                  <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="customdash_unit" value="MM" type="QString"/>
+                  <Option name="dash_pattern_offset" value="0" type="QString"/>
+                  <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                  <Option name="draw_inside_polygon" value="0" type="QString"/>
+                  <Option name="joinstyle" value="bevel" type="QString"/>
+                  <Option name="line_color" value="35,35,35,255" type="QString"/>
+                  <Option name="line_style" value="solid" type="QString"/>
+                  <Option name="line_width" value="0.26" type="QString"/>
+                  <Option name="line_width_unit" value="MM" type="QString"/>
+                  <Option name="offset" value="0" type="QString"/>
+                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="offset_unit" value="MM" type="QString"/>
+                  <Option name="ring_filter" value="0" type="QString"/>
+                  <Option name="trim_distance_end" value="0" type="QString"/>
+                  <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                  <Option name="trim_distance_start" value="0" type="QString"/>
+                  <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                  <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                  <Option name="use_custom_dash" value="0" type="QString"/>
+                  <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
                 </Option>
-                <prop k="align_dash_pattern" v="0"></prop>
-                <prop k="capstyle" v="square"></prop>
-                <prop k="customdash" v="5;2"></prop>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="customdash_unit" v="MM"></prop>
-                <prop k="dash_pattern_offset" v="0"></prop>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="dash_pattern_offset_unit" v="MM"></prop>
-                <prop k="draw_inside_polygon" v="0"></prop>
-                <prop k="joinstyle" v="bevel"></prop>
-                <prop k="line_color" v="35,35,35,255"></prop>
-                <prop k="line_style" v="solid"></prop>
-                <prop k="line_width" v="0.26"></prop>
-                <prop k="line_width_unit" v="MM"></prop>
-                <prop k="offset" v="0"></prop>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="offset_unit" v="MM"></prop>
-                <prop k="ring_filter" v="0"></prop>
-                <prop k="trim_distance_end" v="0"></prop>
-                <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_end_unit" v="MM"></prop>
-                <prop k="trim_distance_start" v="0"></prop>
-                <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_start_unit" v="MM"></prop>
-                <prop k="tweak_dash_pattern_on_corners" v="0"></prop>
-                <prop k="use_custom_dash" v="0"></prop>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value=""></Option>
-                    <Option name="properties"></Option>
-                    <Option name="type" type="QString" value="collection"></Option>
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -1021,176 +1199,187 @@ def my_form_open(dialog, layer, feature):
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="2" priority="0" showAll="1" zIndex="0">
+      <DiagramLayerSettings priority="0" dist="0" showAll="1" linePlacementFlags="18" obstacle="0" placement="2" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""></Option>
-            <Option name="properties"></Option>
-            <Option name="type" type="QString" value="collection"></Option>
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks></activeChecks>
-        <checkConfiguration></checkConfiguration>
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+        <activeChecks/>
+        <checkConfiguration/>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"></legend>
-      <referencedLayers></referencedLayers>
+      <legend showLabelLegend="0" type="default-vector"/>
+      <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="full_id">
+        <field configurationFlags="NoFlag" name="full_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_id">
+        <field configurationFlags="NoFlag" name="osm_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_type">
+        <field configurationFlags="NoFlag" name="osm_type">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="highway">
+        <field configurationFlags="NoFlag" name="highway">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="name">
+        <field configurationFlags="NoFlag" name="name">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="bicycle">
+        <field configurationFlags="NoFlag" name="bicycle">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="lit">
+        <field configurationFlags="NoFlag" name="lit">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="surface">
+        <field configurationFlags="NoFlag" name="surface">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""></alias>
-        <alias field="full_id" index="1" name=""></alias>
-        <alias field="osm_id" index="2" name=""></alias>
-        <alias field="osm_type" index="3" name=""></alias>
-        <alias field="highway" index="4" name=""></alias>
-        <alias field="name" index="5" name=""></alias>
-        <alias field="bicycle" index="6" name=""></alias>
-        <alias field="lit" index="7" name=""></alias>
-        <alias field="surface" index="8" name=""></alias>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="full_id" index="1"/>
+        <alias name="" field="osm_id" index="2"/>
+        <alias name="" field="osm_type" index="3"/>
+        <alias name="" field="highway" index="4"/>
+        <alias name="" field="name" index="5"/>
+        <alias name="" field="bicycle" index="6"/>
+        <alias name="" field="lit" index="7"/>
+        <alias name="" field="surface" index="8"/>
       </aliases>
+      <splitPolicies>
+        <policy field="id" policy="Duplicate"/>
+        <policy field="full_id" policy="Duplicate"/>
+        <policy field="osm_id" policy="Duplicate"/>
+        <policy field="osm_type" policy="Duplicate"/>
+        <policy field="highway" policy="Duplicate"/>
+        <policy field="name" policy="Duplicate"/>
+        <policy field="bicycle" policy="Duplicate"/>
+        <policy field="lit" policy="Duplicate"/>
+        <policy field="surface" policy="Duplicate"/>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="id"></default>
-        <default applyOnUpdate="0" expression="" field="full_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_type"></default>
-        <default applyOnUpdate="0" expression="" field="highway"></default>
-        <default applyOnUpdate="0" expression="" field="name"></default>
-        <default applyOnUpdate="0" expression="" field="bicycle"></default>
-        <default applyOnUpdate="0" expression="" field="lit"></default>
-        <default applyOnUpdate="0" expression="" field="surface"></default>
+        <default field="id" applyOnUpdate="0" expression=""/>
+        <default field="full_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_type" applyOnUpdate="0" expression=""/>
+        <default field="highway" applyOnUpdate="0" expression=""/>
+        <default field="name" applyOnUpdate="0" expression=""/>
+        <default field="bicycle" applyOnUpdate="0" expression=""/>
+        <default field="lit" applyOnUpdate="0" expression=""/>
+        <default field="surface" applyOnUpdate="0" expression=""/>
       </defaults>
       <constraints>
-        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
-        <constraint constraints="0" exp_strength="0" field="full_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_type" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="highway" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="bicycle" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="lit" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="surface" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint notnull_strength="1" field="id" unique_strength="1" constraints="3" exp_strength="0"/>
+        <constraint notnull_strength="0" field="full_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_type" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="highway" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="name" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="bicycle" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="lit" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="surface" unique_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"></constraint>
-        <constraint desc="" exp="" field="full_id"></constraint>
-        <constraint desc="" exp="" field="osm_id"></constraint>
-        <constraint desc="" exp="" field="osm_type"></constraint>
-        <constraint desc="" exp="" field="highway"></constraint>
-        <constraint desc="" exp="" field="name"></constraint>
-        <constraint desc="" exp="" field="bicycle"></constraint>
-        <constraint desc="" exp="" field="lit"></constraint>
-        <constraint desc="" exp="" field="surface"></constraint>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="full_id" exp=""/>
+        <constraint desc="" field="osm_id" exp=""/>
+        <constraint desc="" field="osm_type" exp=""/>
+        <constraint desc="" field="highway" exp=""/>
+        <constraint desc="" field="name" exp=""/>
+        <constraint desc="" field="bicycle" exp=""/>
+        <constraint desc="" field="lit" exp=""/>
+        <constraint desc="" field="surface" exp=""/>
       </constraintExpressions>
-      <expressionfields></expressionfields>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
-        <actionsetting action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" capture="0" icon="" id="{959bb355-42ad-470e-b26e-f36323b8ff58}" isEnabledOnlyWhenEditable="0" name="OpenStreetMap Browser" notificationMessage="" shortTitle="OpenStreetMap Browser" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <actionsetting notificationMessage="" name="OpenStreetMap Browser" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" shortTitle="OpenStreetMap Browser" icon="" id="{959bb355-42ad-470e-b26e-f36323b8ff58}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{b410f6b2-0c1d-4e44-98c8-e643b3cc0c55}" isEnabledOnlyWhenEditable="0" name="JOSM" notificationMessage="" shortTitle="JOSM" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="JOSM" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" shortTitle="JOSM" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{b410f6b2-0c1d-4e44-98c8-e643b3cc0c55}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" capture="0" icon="" id="{9d8d9427-62e0-4ee0-bc4e-02072921d75d}" isEnabledOnlyWhenEditable="0" name="User default editor" notificationMessage="" shortTitle="User default editor" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="User default editor" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" shortTitle="User default editor" icon="" id="{9d8d9427-62e0-4ee0-bc4e-02072921d75d}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Tracks and paths&quot;)" capture="0" icon="" id="{a9f5c37b-1870-47b8-ac84-658df03a4f12}" isEnabledOnlyWhenEditable="0" name="Reload the query in a new file" notificationMessage="" shortTitle="Reload the query in a new file" type="1">
-          <actionScope id="Layer"></actionScope>
+        <actionsetting notificationMessage="" name="Reload the query in a new file" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Tracks and paths&quot;)" shortTitle="Reload the query in a new file" icon="" id="{a9f5c37b-1870-47b8-ac84-658df03a4f12}">
+          <actionScope id="Layer"/>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
         <columns>
-          <column hidden="0" name="full_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_type" type="field" width="-1"></column>
-          <column hidden="0" name="highway" type="field" width="-1"></column>
-          <column hidden="0" name="name" type="field" width="-1"></column>
-          <column hidden="0" name="bicycle" type="field" width="-1"></column>
-          <column hidden="0" name="surface" type="field" width="-1"></column>
-          <column hidden="0" name="lit" type="field" width="-1"></column>
-          <column hidden="1" type="actions" width="-1"></column>
-          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column name="full_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_type" hidden="0" type="field" width="-1"/>
+          <column name="highway" hidden="0" type="field" width="-1"/>
+          <column name="name" hidden="0" type="field" width="-1"/>
+          <column name="bicycle" hidden="0" type="field" width="-1"/>
+          <column name="surface" hidden="0" type="field" width="-1"/>
+          <column name="lit" hidden="0" type="field" width="-1"/>
+          <column hidden="1" type="actions" width="-1"/>
+          <column name="id" hidden="0" type="field" width="-1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles></rowstyles>
-        <fieldstyles></fieldstyles>
+        <rowstyles/>
+        <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions></storedexpressions>
+      <storedexpressions/>
       <editform tolerant="1"></editform>
-      <editforminit></editforminit>
+      <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode># -*- coding: utf-8 -*-
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1206,44 +1395,44 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-</editforminitcode>
+]]></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="bicycle"></field>
-        <field editable="1" name="bridge"></field>
-        <field editable="1" name="full_id"></field>
-        <field editable="1" name="highway"></field>
-        <field editable="1" name="id"></field>
-        <field editable="1" name="layer"></field>
-        <field editable="1" name="lit"></field>
-        <field editable="1" name="name"></field>
-        <field editable="1" name="osm_id"></field>
-        <field editable="1" name="osm_type"></field>
-        <field editable="1" name="surface"></field>
-        <field editable="1" name="tunnel"></field>
+        <field name="bicycle" editable="1"/>
+        <field name="bridge" editable="1"/>
+        <field name="full_id" editable="1"/>
+        <field name="highway" editable="1"/>
+        <field name="id" editable="1"/>
+        <field name="layer" editable="1"/>
+        <field name="lit" editable="1"/>
+        <field name="name" editable="1"/>
+        <field name="osm_id" editable="1"/>
+        <field name="osm_type" editable="1"/>
+        <field name="surface" editable="1"/>
+        <field name="tunnel" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="bicycle"></field>
-        <field labelOnTop="0" name="bridge"></field>
-        <field labelOnTop="0" name="full_id"></field>
-        <field labelOnTop="0" name="highway"></field>
-        <field labelOnTop="0" name="id"></field>
-        <field labelOnTop="0" name="layer"></field>
-        <field labelOnTop="0" name="lit"></field>
-        <field labelOnTop="0" name="name"></field>
-        <field labelOnTop="0" name="osm_id"></field>
-        <field labelOnTop="0" name="osm_type"></field>
-        <field labelOnTop="0" name="surface"></field>
-        <field labelOnTop="0" name="tunnel"></field>
+        <field name="bicycle" labelOnTop="0"/>
+        <field name="bridge" labelOnTop="0"/>
+        <field name="full_id" labelOnTop="0"/>
+        <field name="highway" labelOnTop="0"/>
+        <field name="id" labelOnTop="0"/>
+        <field name="layer" labelOnTop="0"/>
+        <field name="lit" labelOnTop="0"/>
+        <field name="name" labelOnTop="0"/>
+        <field name="osm_id" labelOnTop="0"/>
+        <field name="osm_type" labelOnTop="0"/>
+        <field name="surface" labelOnTop="0"/>
+        <field name="tunnel" labelOnTop="0"/>
       </labelOnTop>
-      <reuseLastValue></reuseLastValue>
-      <dataDefinedFieldProperties></dataDefinedFieldProperties>
-      <widgets></widgets>
+      <reuseLastValue/>
+      <dataDefinedFieldProperties/>
+      <widgets/>
       <previewExpression>"name"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
+    <maplayer autoRefreshMode="Disabled" simplifyAlgorithm="0" minScale="100000000" simplifyLocal="1" legendPlaceholderImage="" readOnly="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" maxScale="0" autoRefreshTime="0" wkbType="MultiPolygon" simplifyMaxScale="1" geometry="Polygon" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" type="vector" simplifyDrawingTol="1" symbologyReferenceScale="-1" labelsEnabled="0">
       <extent>
         <xmin>3.86957189999999995</xmin>
         <ymin>43.61217620000000039</ymin>
@@ -1263,8 +1452,8 @@ def my_form_open(dialog, layer, feature):
       </keywordList>
       <layername>gardens</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -1291,12 +1480,13 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links></links>
+        <links/>
+        <dates/>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
-            <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
             <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>3452</srsid>
             <srid>4326</srid>
@@ -1308,7 +1498,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="EPSG:4326" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
+          <spatial minz="0" maxx="0" maxy="0" crs="EPSG:4326" minx="0" dimensions="2" miny="0" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -1318,164 +1508,261 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins></vectorjoins>
-      <layerDependencies></layerDependencies>
-      <dataDependencies></dataDependencies>
-      <expressionfields></expressionfields>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"></map-layer-style>
+        <map-layer-style name="default"/>
       </map-layer-style-manager>
-      <auxiliaryLayer></auxiliaryLayer>
-      <metadataUrls></metadataUrls>
+      <auxiliaryLayer/>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+      <temporal startField="" accumulate="0" endField="" limitMode="0" durationUnit="min" enabled="0" fixedDuration="0" mode="0" durationField="" endExpression="" startExpression="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
-        <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+      <elevation zoffset="0" respectLayerSymbol="1" extrusion="0" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" type="IndividualFeatures" zscale="1" binding="Centroid" extrusionEnabled="0">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""></Option>
-                <Option name="properties"></Option>
-                <Option name="type" type="QString" value="collection"></Option>
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{fb8aed4e-9366-42d9-abf9-11fb20fa3602}">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="color" type="QString" value="196,227,197,255"></Option>
-                <Option name="joinstyle" type="QString" value="bevel"></Option>
-                <Option name="offset" type="QString" value="0,0"></Option>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="offset_unit" type="QString" value="MM"></Option>
-                <Option name="outline_color" type="QString" value="174,200,174,255"></Option>
-                <Option name="outline_style" type="QString" value="solid"></Option>
-                <Option name="outline_width" type="QString" value="0.3"></Option>
-                <Option name="outline_width_unit" type="QString" value="MM"></Option>
-                <Option name="style" type="QString" value="solid"></Option>
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="square" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="line_color" value="196,60,57,255" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.6" type="QString"/>
+                <Option name="line_width_unit" value="MM" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="color" v="196,227,197,255"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="offset" v="0,0"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="outline_color" v="174,200,174,255"></prop>
-              <prop k="outline_style" v="solid"></prop>
-              <prop k="outline_width" v="0.3"></prop>
-              <prop k="outline_width_unit" v="MM"></prop>
-              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{9f5e5c30-10bb-4139-b9fe-3bca4c9d688e}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="196,60,57,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="140,43,41,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{03af5986-65c3-4ceb-a92c-e1261865b808}">
+              <Option type="Map">
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="196,60,57,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="diamond" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="140,43,41,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="3" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MM" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
+        <symbols>
+          <symbol clip_to_extent="1" name="0" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{7e4c01eb-4895-427d-b2be-db259c5cc5c1}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="196,227,197,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="174,200,174,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.3" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation></rotation>
-        <sizescale></sizescale>
+        <rotation/>
+        <sizescale/>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"/>
+      </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="OnConvertFormatRegeneratePrimaryKey" type="QString" value="false"></Option>
-          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
-          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
-          <Option name="variableNames" type="QString" value="quickosm_query"></Option>
-          <Option name="variableValues" type="QString" value="[out:xml] [timeout:25];&#xA;(&#xA;    node[&quot;leisure&quot;=&quot;garden&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    node[&quot;leisure&quot;=&quot;park&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;leisure&quot;=&quot;garden&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;leisure&quot;=&quot;park&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;leisure&quot;=&quot;garden&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;leisure&quot;=&quot;park&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;);&#xA;(._;>;);&#xA;out body;"></Option>
+          <Option name="OnConvertFormatRegeneratePrimaryKey" value="false" type="QString"/>
+          <Option name="QFieldSync/action" value="offline" type="QString"/>
+          <Option name="QFieldSync/cloud_action" value="offline" type="QString"/>
+          <Option name="QFieldSync/photo_naming" value="{}" type="QString"/>
+          <Option name="embeddedWidgets/count" value="0" type="QString"/>
+          <Option name="variableNames" value="quickosm_query" type="QString"/>
+          <Option name="variableValues" value="[out:xml] [timeout:25];&#xa;(&#xa;    node[&quot;leisure&quot;=&quot;garden&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    node[&quot;leisure&quot;=&quot;park&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;leisure&quot;=&quot;garden&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;leisure&quot;=&quot;park&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;leisure&quot;=&quot;garden&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;leisure&quot;=&quot;park&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;);&#xa;(._;>;);&#xa;out body;" type="QString"/>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="0" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="1" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="5" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
-          <attribute color="#000000" field="" label=""></attribute>
+        <DiagramCategory scaleDependency="Area" sizeType="MM" spacingUnit="MM" direction="0" height="15" rotationOffset="270" barWidth="5" scaleBasedVisibility="0" penColor="#000000" minimumSize="0" spacingUnitScale="3x:0,0,0,0,0,0" backgroundAlpha="255" showAxis="1" opacity="1" minScaleDenominator="0" penAlpha="255" width="15" enabled="0" penWidth="0" diagramOrientation="Up" spacing="5" lineSizeType="MM" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" backgroundColor="#ffffff" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0">
+          <fontProperties bold="0" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" underline="0" style="" strikethrough="0"/>
+          <attribute field="" color="#000000" label="" colorOpacity="1"/>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+            <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{a0d68f7d-8b9e-4cca-9426-732689bcfd48}">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
-                  <Option name="capstyle" type="QString" value="square"></Option>
-                  <Option name="customdash" type="QString" value="5;2"></Option>
-                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="customdash_unit" type="QString" value="MM"></Option>
-                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
-                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
-                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
-                  <Option name="joinstyle" type="QString" value="bevel"></Option>
-                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
-                  <Option name="line_style" type="QString" value="solid"></Option>
-                  <Option name="line_width" type="QString" value="0.26"></Option>
-                  <Option name="line_width_unit" type="QString" value="MM"></Option>
-                  <Option name="offset" type="QString" value="0"></Option>
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="offset_unit" type="QString" value="MM"></Option>
-                  <Option name="ring_filter" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
-                  <Option name="trim_distance_start" type="QString" value="0"></Option>
-                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
-                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
-                  <Option name="use_custom_dash" type="QString" value="0"></Option>
-                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="align_dash_pattern" value="0" type="QString"/>
+                  <Option name="capstyle" value="square" type="QString"/>
+                  <Option name="customdash" value="5;2" type="QString"/>
+                  <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="customdash_unit" value="MM" type="QString"/>
+                  <Option name="dash_pattern_offset" value="0" type="QString"/>
+                  <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                  <Option name="draw_inside_polygon" value="0" type="QString"/>
+                  <Option name="joinstyle" value="bevel" type="QString"/>
+                  <Option name="line_color" value="35,35,35,255" type="QString"/>
+                  <Option name="line_style" value="solid" type="QString"/>
+                  <Option name="line_width" value="0.26" type="QString"/>
+                  <Option name="line_width_unit" value="MM" type="QString"/>
+                  <Option name="offset" value="0" type="QString"/>
+                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="offset_unit" value="MM" type="QString"/>
+                  <Option name="ring_filter" value="0" type="QString"/>
+                  <Option name="trim_distance_end" value="0" type="QString"/>
+                  <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                  <Option name="trim_distance_start" value="0" type="QString"/>
+                  <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                  <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                  <Option name="use_custom_dash" value="0" type="QString"/>
+                  <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
                 </Option>
-                <prop k="align_dash_pattern" v="0"></prop>
-                <prop k="capstyle" v="square"></prop>
-                <prop k="customdash" v="5;2"></prop>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="customdash_unit" v="MM"></prop>
-                <prop k="dash_pattern_offset" v="0"></prop>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="dash_pattern_offset_unit" v="MM"></prop>
-                <prop k="draw_inside_polygon" v="0"></prop>
-                <prop k="joinstyle" v="bevel"></prop>
-                <prop k="line_color" v="35,35,35,255"></prop>
-                <prop k="line_style" v="solid"></prop>
-                <prop k="line_width" v="0.26"></prop>
-                <prop k="line_width_unit" v="MM"></prop>
-                <prop k="offset" v="0"></prop>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="offset_unit" v="MM"></prop>
-                <prop k="ring_filter" v="0"></prop>
-                <prop k="trim_distance_end" v="0"></prop>
-                <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_end_unit" v="MM"></prop>
-                <prop k="trim_distance_start" v="0"></prop>
-                <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_start_unit" v="MM"></prop>
-                <prop k="tweak_dash_pattern_on_corners" v="0"></prop>
-                <prop k="use_custom_dash" v="0"></prop>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value=""></Option>
-                    <Option name="properties"></Option>
-                    <Option name="type" type="QString" value="collection"></Option>
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -1483,180 +1770,190 @@ def my_form_open(dialog, layer, feature):
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
+      <DiagramLayerSettings priority="0" dist="0" showAll="1" linePlacementFlags="18" obstacle="0" placement="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""></Option>
-            <Option name="properties"></Option>
-            <Option name="type" type="QString" value="collection"></Option>
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks></activeChecks>
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+        <activeChecks/>
         <checkConfiguration type="Map">
           <Option name="QgsGeometryGapCheck" type="Map">
-            <Option name="allowedGapsBuffer" type="double" value="0"></Option>
-            <Option name="allowedGapsEnabled" type="bool" value="false"></Option>
-            <Option name="allowedGapsLayer" type="QString" value=""></Option>
+            <Option name="allowedGapsBuffer" value="0" type="double"/>
+            <Option name="allowedGapsEnabled" value="false" type="bool"/>
+            <Option name="allowedGapsLayer" value="" type="QString"/>
           </Option>
         </checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"></legend>
-      <referencedLayers></referencedLayers>
+      <legend showLabelLegend="0" type="default-vector"/>
+      <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="full_id">
+        <field configurationFlags="NoFlag" name="full_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_id">
+        <field configurationFlags="NoFlag" name="osm_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_type">
+        <field configurationFlags="NoFlag" name="osm_type">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="leisure">
+        <field configurationFlags="NoFlag" name="leisure">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="name">
+        <field configurationFlags="NoFlag" name="name">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="landuse">
+        <field configurationFlags="NoFlag" name="landuse">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="wikipedia">
+        <field configurationFlags="NoFlag" name="wikipedia">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""></alias>
-        <alias field="full_id" index="1" name=""></alias>
-        <alias field="osm_id" index="2" name=""></alias>
-        <alias field="osm_type" index="3" name=""></alias>
-        <alias field="leisure" index="4" name=""></alias>
-        <alias field="name" index="5" name=""></alias>
-        <alias field="landuse" index="6" name=""></alias>
-        <alias field="wikipedia" index="7" name=""></alias>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="full_id" index="1"/>
+        <alias name="" field="osm_id" index="2"/>
+        <alias name="" field="osm_type" index="3"/>
+        <alias name="" field="leisure" index="4"/>
+        <alias name="" field="name" index="5"/>
+        <alias name="" field="landuse" index="6"/>
+        <alias name="" field="wikipedia" index="7"/>
       </aliases>
+      <splitPolicies>
+        <policy field="id" policy="Duplicate"/>
+        <policy field="full_id" policy="Duplicate"/>
+        <policy field="osm_id" policy="Duplicate"/>
+        <policy field="osm_type" policy="Duplicate"/>
+        <policy field="leisure" policy="Duplicate"/>
+        <policy field="name" policy="Duplicate"/>
+        <policy field="landuse" policy="Duplicate"/>
+        <policy field="wikipedia" policy="Duplicate"/>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="id"></default>
-        <default applyOnUpdate="0" expression="" field="full_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_type"></default>
-        <default applyOnUpdate="0" expression="" field="leisure"></default>
-        <default applyOnUpdate="0" expression="" field="name"></default>
-        <default applyOnUpdate="0" expression="" field="landuse"></default>
-        <default applyOnUpdate="0" expression="" field="wikipedia"></default>
+        <default field="id" applyOnUpdate="0" expression=""/>
+        <default field="full_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_type" applyOnUpdate="0" expression=""/>
+        <default field="leisure" applyOnUpdate="0" expression=""/>
+        <default field="name" applyOnUpdate="0" expression=""/>
+        <default field="landuse" applyOnUpdate="0" expression=""/>
+        <default field="wikipedia" applyOnUpdate="0" expression=""/>
       </defaults>
       <constraints>
-        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
-        <constraint constraints="0" exp_strength="0" field="full_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_type" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="leisure" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="name" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="landuse" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="wikipedia" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint notnull_strength="1" field="id" unique_strength="1" constraints="3" exp_strength="0"/>
+        <constraint notnull_strength="0" field="full_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_type" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="leisure" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="name" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="landuse" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="wikipedia" unique_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"></constraint>
-        <constraint desc="" exp="" field="full_id"></constraint>
-        <constraint desc="" exp="" field="osm_id"></constraint>
-        <constraint desc="" exp="" field="osm_type"></constraint>
-        <constraint desc="" exp="" field="leisure"></constraint>
-        <constraint desc="" exp="" field="name"></constraint>
-        <constraint desc="" exp="" field="landuse"></constraint>
-        <constraint desc="" exp="" field="wikipedia"></constraint>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="full_id" exp=""/>
+        <constraint desc="" field="osm_id" exp=""/>
+        <constraint desc="" field="osm_type" exp=""/>
+        <constraint desc="" field="leisure" exp=""/>
+        <constraint desc="" field="name" exp=""/>
+        <constraint desc="" field="landuse" exp=""/>
+        <constraint desc="" field="wikipedia" exp=""/>
       </constraintExpressions>
-      <expressionfields></expressionfields>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
-        <actionsetting action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" capture="0" icon="" id="{25ea93e2-636d-4ba8-a1f0-9bbbd153ca02}" isEnabledOnlyWhenEditable="0" name="OpenStreetMap Browser" notificationMessage="" shortTitle="OpenStreetMap Browser" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <actionsetting notificationMessage="" name="OpenStreetMap Browser" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" shortTitle="OpenStreetMap Browser" icon="" id="{25ea93e2-636d-4ba8-a1f0-9bbbd153ca02}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{dedb11fa-b530-4ead-8042-040cfdb07b03}" isEnabledOnlyWhenEditable="0" name="JOSM" notificationMessage="" shortTitle="JOSM" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="JOSM" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" shortTitle="JOSM" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{dedb11fa-b530-4ead-8042-040cfdb07b03}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" capture="0" icon="" id="{def5adb7-24ce-4a31-811f-9f299e66852b}" isEnabledOnlyWhenEditable="0" name="User default editor" notificationMessage="" shortTitle="User default editor" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="User default editor" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" shortTitle="User default editor" icon="" id="{def5adb7-24ce-4a31-811f-9f299e66852b}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;wikipedia&quot;,&quot;[% &quot;wikipedia&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/wikipedia.png" id="{4559286e-6aca-41f4-b15f-00639fa9459e}" isEnabledOnlyWhenEditable="0" name="wikipedia" notificationMessage="" shortTitle="wikipedia" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="wikipedia" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;wikipedia&quot;,&quot;[% &quot;wikipedia&quot; %]&quot;)" shortTitle="wikipedia" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/wikipedia.png" id="{4559286e-6aca-41f4-b15f-00639fa9459e}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;wikidata&quot;,&quot;[% &quot;wikidata&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/wikidata.png" id="{6efb99f1-5c5b-407f-b390-fdbc8cc891b7}" isEnabledOnlyWhenEditable="0" name="wikidata" notificationMessage="" shortTitle="wikidata" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="wikidata" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;wikidata&quot;,&quot;[% &quot;wikidata&quot; %]&quot;)" shortTitle="wikidata" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/wikidata.png" id="{6efb99f1-5c5b-407f-b390-fdbc8cc891b7}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Gardens&quot;)" capture="0" icon="" id="{6ccd94e2-33ed-45aa-91bc-7848dd679172}" isEnabledOnlyWhenEditable="0" name="Reload the query in a new file" notificationMessage="" shortTitle="Reload the query in a new file" type="1">
-          <actionScope id="Layer"></actionScope>
+        <actionsetting notificationMessage="" name="Reload the query in a new file" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Gardens&quot;)" shortTitle="Reload the query in a new file" icon="" id="{6ccd94e2-33ed-45aa-91bc-7848dd679172}">
+          <actionScope id="Layer"/>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
         <columns>
-          <column hidden="0" name="full_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_type" type="field" width="-1"></column>
-          <column hidden="0" name="leisure" type="field" width="-1"></column>
-          <column hidden="0" name="wikipedia" type="field" width="-1"></column>
-          <column hidden="0" name="name" type="field" width="-1"></column>
-          <column hidden="1" type="actions" width="-1"></column>
-          <column hidden="0" name="id" type="field" width="-1"></column>
-          <column hidden="0" name="landuse" type="field" width="-1"></column>
+          <column name="full_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_type" hidden="0" type="field" width="-1"/>
+          <column name="leisure" hidden="0" type="field" width="-1"/>
+          <column name="wikipedia" hidden="0" type="field" width="-1"/>
+          <column name="name" hidden="0" type="field" width="-1"/>
+          <column hidden="1" type="actions" width="-1"/>
+          <column name="id" hidden="0" type="field" width="-1"/>
+          <column name="landuse" hidden="0" type="field" width="-1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles></rowstyles>
-        <fieldstyles></fieldstyles>
+        <rowstyles/>
+        <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions></storedexpressions>
+      <storedexpressions/>
       <editform tolerant="1"></editform>
-      <editforminit></editforminit>
+      <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode># -*- coding: utf-8 -*-
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -1672,58 +1969,58 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-</editforminitcode>
+]]></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="access"></field>
-        <field editable="1" name="barrier"></field>
-        <field editable="1" name="bicycle"></field>
-        <field editable="1" name="foot"></field>
-        <field editable="1" name="full_id"></field>
-        <field editable="1" name="heritage"></field>
-        <field editable="1" name="heritage:operator"></field>
-        <field editable="1" name="id"></field>
-        <field editable="1" name="landuse"></field>
-        <field editable="1" name="leisure"></field>
-        <field editable="1" name="mhs:inscription_date"></field>
-        <field editable="1" name="motorcar"></field>
-        <field editable="1" name="motorcycle"></field>
-        <field editable="1" name="name"></field>
-        <field editable="1" name="osm_id"></field>
-        <field editable="1" name="osm_type"></field>
-        <field editable="1" name="ref:mhs"></field>
-        <field editable="1" name="wikidata"></field>
-        <field editable="1" name="wikipedia"></field>
+        <field name="access" editable="1"/>
+        <field name="barrier" editable="1"/>
+        <field name="bicycle" editable="1"/>
+        <field name="foot" editable="1"/>
+        <field name="full_id" editable="1"/>
+        <field name="heritage" editable="1"/>
+        <field name="heritage:operator" editable="1"/>
+        <field name="id" editable="1"/>
+        <field name="landuse" editable="1"/>
+        <field name="leisure" editable="1"/>
+        <field name="mhs:inscription_date" editable="1"/>
+        <field name="motorcar" editable="1"/>
+        <field name="motorcycle" editable="1"/>
+        <field name="name" editable="1"/>
+        <field name="osm_id" editable="1"/>
+        <field name="osm_type" editable="1"/>
+        <field name="ref:mhs" editable="1"/>
+        <field name="wikidata" editable="1"/>
+        <field name="wikipedia" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="access"></field>
-        <field labelOnTop="0" name="barrier"></field>
-        <field labelOnTop="0" name="bicycle"></field>
-        <field labelOnTop="0" name="foot"></field>
-        <field labelOnTop="0" name="full_id"></field>
-        <field labelOnTop="0" name="heritage"></field>
-        <field labelOnTop="0" name="heritage:operator"></field>
-        <field labelOnTop="0" name="id"></field>
-        <field labelOnTop="0" name="landuse"></field>
-        <field labelOnTop="0" name="leisure"></field>
-        <field labelOnTop="0" name="mhs:inscription_date"></field>
-        <field labelOnTop="0" name="motorcar"></field>
-        <field labelOnTop="0" name="motorcycle"></field>
-        <field labelOnTop="0" name="name"></field>
-        <field labelOnTop="0" name="osm_id"></field>
-        <field labelOnTop="0" name="osm_type"></field>
-        <field labelOnTop="0" name="ref:mhs"></field>
-        <field labelOnTop="0" name="wikidata"></field>
-        <field labelOnTop="0" name="wikipedia"></field>
+        <field name="access" labelOnTop="0"/>
+        <field name="barrier" labelOnTop="0"/>
+        <field name="bicycle" labelOnTop="0"/>
+        <field name="foot" labelOnTop="0"/>
+        <field name="full_id" labelOnTop="0"/>
+        <field name="heritage" labelOnTop="0"/>
+        <field name="heritage:operator" labelOnTop="0"/>
+        <field name="id" labelOnTop="0"/>
+        <field name="landuse" labelOnTop="0"/>
+        <field name="leisure" labelOnTop="0"/>
+        <field name="mhs:inscription_date" labelOnTop="0"/>
+        <field name="motorcar" labelOnTop="0"/>
+        <field name="motorcycle" labelOnTop="0"/>
+        <field name="name" labelOnTop="0"/>
+        <field name="osm_id" labelOnTop="0"/>
+        <field name="osm_type" labelOnTop="0"/>
+        <field name="ref:mhs" labelOnTop="0"/>
+        <field name="wikidata" labelOnTop="0"/>
+        <field name="wikipedia" labelOnTop="0"/>
       </labelOnTop>
-      <reuseLastValue></reuseLastValue>
-      <dataDefinedFieldProperties></dataDefinedFieldProperties>
-      <widgets></widgets>
+      <reuseLastValue/>
+      <dataDefinedFieldProperties/>
+      <widgets/>
       <previewExpression>"name"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Point" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="Point">
+    <maplayer autoRefreshMode="Disabled" simplifyAlgorithm="0" minScale="100000000" simplifyLocal="1" legendPlaceholderImage="" readOnly="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="0" refreshOnNotifyMessage="" maxScale="0" autoRefreshTime="0" wkbType="Point" simplifyMaxScale="1" geometry="Point" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" type="vector" simplifyDrawingTol="1" symbologyReferenceScale="-1" labelsEnabled="0">
       <extent>
         <xmin>3.86999940872192383</xmin>
         <ymin>43.61251068115234375</ymin>
@@ -1743,8 +2040,8 @@ def my_form_open(dialog, layer, feature):
       </keywordList>
       <layername>trees</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -1771,12 +2068,13 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links></links>
+        <links/>
+        <dates/>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
-            <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
             <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>3452</srsid>
             <srid>4326</srid>
@@ -1788,7 +2086,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="EPSG:4326" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
+          <spatial minz="0" maxx="0" maxy="0" crs="EPSG:4326" minx="0" dimensions="2" miny="0" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -1798,348 +2096,373 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins></vectorjoins>
-      <layerDependencies></layerDependencies>
-      <dataDependencies></dataDependencies>
-      <expressionfields></expressionfields>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"></map-layer-style>
+        <map-layer-style name="default"/>
       </map-layer-style-manager>
-      <auxiliaryLayer></auxiliaryLayer>
-      <metadataUrls></metadataUrls>
+      <auxiliaryLayer/>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+      <temporal startField="" accumulate="0" endField="" limitMode="0" durationUnit="min" enabled="0" fixedDuration="0" mode="0" durationField="" endExpression="" startExpression="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
-        <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="marker">
+      <elevation zoffset="0" respectLayerSymbol="1" extrusion="0" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" type="IndividualFeatures" zscale="1" binding="Centroid" extrusionEnabled="0">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""></Option>
-                <Option name="properties"></Option>
-                <Option name="type" type="QString" value="collection"></Option>
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{a691943c-022f-4a40-a9d7-bd7cd74afe3d}">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0"></Option>
-                <Option name="cap_style" type="QString" value="square"></Option>
-                <Option name="color" type="QString" value="84,134,58,255"></Option>
-                <Option name="horizontal_anchor_point" type="QString" value="1"></Option>
-                <Option name="joinstyle" type="QString" value="bevel"></Option>
-                <Option name="name" type="QString" value="circle"></Option>
-                <Option name="offset" type="QString" value="0,0"></Option>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="offset_unit" type="QString" value="MM"></Option>
-                <Option name="outline_color" type="QString" value="84,134,58,255"></Option>
-                <Option name="outline_style" type="QString" value="solid"></Option>
-                <Option name="outline_width" type="QString" value="0"></Option>
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="outline_width_unit" type="QString" value="MM"></Option>
-                <Option name="scale_method" type="QString" value="diameter"></Option>
-                <Option name="size" type="QString" value="2"></Option>
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="size_unit" type="QString" value="RenderMetersInMapUnits"></Option>
-                <Option name="vertical_anchor_point" type="QString" value="1"></Option>
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="square" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="line_color" value="190,178,151,255" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.6" type="QString"/>
+                <Option name="line_width_unit" value="MM" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop k="angle" v="0"></prop>
-              <prop k="cap_style" v="square"></prop>
-              <prop k="color" v="84,134,58,255"></prop>
-              <prop k="horizontal_anchor_point" v="1"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="name" v="circle"></prop>
-              <prop k="offset" v="0,0"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="outline_color" v="84,134,58,255"></prop>
-              <prop k="outline_style" v="solid"></prop>
-              <prop k="outline_width" v="0"></prop>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="outline_width_unit" v="MM"></prop>
-              <prop k="scale_method" v="diameter"></prop>
-              <prop k="size" v="2"></prop>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="size_unit" v="RenderMetersInMapUnits"></prop>
-              <prop k="vertical_anchor_point" v="1"></prop>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{f4a00771-21d5-4c53-8076-6c5fb46607fb}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="190,178,151,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="136,127,108,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{3c95f858-a573-4cb3-bcd9-6d3a5b2d17cc}">
+              <Option type="Map">
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="190,178,151,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="diamond" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="136,127,108,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="3" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MM" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
+        <symbols>
+          <symbol clip_to_extent="1" name="0" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{c04b6ef7-374d-4d48-9e68-c64bfa8b3846}">
+              <Option type="Map">
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="84,134,58,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="84,134,58,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="2" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="RenderMetersInMapUnits" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
+              </Option>
               <effect enabled="1" type="effectStack">
                 <effect type="blur">
                   <Option type="Map">
-                    <Option name="blend_mode" type="QString" value="0"></Option>
-                    <Option name="blur_level" type="QString" value="2.445"></Option>
-                    <Option name="blur_method" type="QString" value="0"></Option>
-                    <Option name="blur_unit" type="QString" value="MM"></Option>
-                    <Option name="blur_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                    <Option name="draw_mode" type="QString" value="2"></Option>
-                    <Option name="enabled" type="QString" value="1"></Option>
-                    <Option name="opacity" type="QString" value="1"></Option>
+                    <Option name="blend_mode" value="0" type="QString"/>
+                    <Option name="blur_level" value="2.445" type="QString"/>
+                    <Option name="blur_method" value="0" type="QString"/>
+                    <Option name="blur_unit" value="MM" type="QString"/>
+                    <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="draw_mode" value="2" type="QString"/>
+                    <Option name="enabled" value="1" type="QString"/>
+                    <Option name="opacity" value="1" type="QString"/>
                   </Option>
-                  <prop k="blend_mode" v="0"></prop>
-                  <prop k="blur_level" v="2.445"></prop>
-                  <prop k="blur_method" v="0"></prop>
-                  <prop k="blur_unit" v="MM"></prop>
-                  <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="draw_mode" v="2"></prop>
-                  <prop k="enabled" v="1"></prop>
-                  <prop k="opacity" v="1"></prop>
                 </effect>
                 <effect type="dropShadow">
                   <Option type="Map">
-                    <Option name="blend_mode" type="QString" value="13"></Option>
-                    <Option name="blur_level" type="QString" value="1.045"></Option>
-                    <Option name="blur_unit" type="QString" value="MM"></Option>
-                    <Option name="blur_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                    <Option name="color" type="QString" value="84,134,58,255"></Option>
-                    <Option name="draw_mode" type="QString" value="2"></Option>
-                    <Option name="enabled" type="QString" value="1"></Option>
-                    <Option name="offset_angle" type="QString" value="150"></Option>
-                    <Option name="offset_distance" type="QString" value="1"></Option>
-                    <Option name="offset_unit" type="QString" value="MM"></Option>
-                    <Option name="offset_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                    <Option name="opacity" type="QString" value="1"></Option>
+                    <Option name="blend_mode" value="13" type="QString"/>
+                    <Option name="blur_level" value="1.045" type="QString"/>
+                    <Option name="blur_unit" value="MM" type="QString"/>
+                    <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="84,134,58,255" type="QString"/>
+                    <Option name="draw_mode" value="2" type="QString"/>
+                    <Option name="enabled" value="1" type="QString"/>
+                    <Option name="offset_angle" value="150" type="QString"/>
+                    <Option name="offset_distance" value="1" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="offset_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="opacity" value="1" type="QString"/>
                   </Option>
-                  <prop k="blend_mode" v="13"></prop>
-                  <prop k="blur_level" v="1.045"></prop>
-                  <prop k="blur_unit" v="MM"></prop>
-                  <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="color" v="84,134,58,255"></prop>
-                  <prop k="draw_mode" v="2"></prop>
-                  <prop k="enabled" v="1"></prop>
-                  <prop k="offset_angle" v="150"></prop>
-                  <prop k="offset_distance" v="1"></prop>
-                  <prop k="offset_unit" v="MM"></prop>
-                  <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="opacity" v="1"></prop>
                 </effect>
                 <effect type="outerGlow">
                   <Option type="Map">
-                    <Option name="blend_mode" type="QString" value="0"></Option>
-                    <Option name="blur_level" type="QString" value="2.645"></Option>
-                    <Option name="blur_unit" type="QString" value="MM"></Option>
-                    <Option name="blur_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                    <Option name="color1" type="QString" value="0,0,255,255"></Option>
-                    <Option name="color2" type="QString" value="0,255,0,255"></Option>
-                    <Option name="color_type" type="QString" value="0"></Option>
-                    <Option name="discrete" type="QString" value="0"></Option>
-                    <Option name="draw_mode" type="QString" value="2"></Option>
-                    <Option name="enabled" type="QString" value="0"></Option>
-                    <Option name="opacity" type="QString" value="0.5"></Option>
-                    <Option name="rampType" type="QString" value="gradient"></Option>
-                    <Option name="single_color" type="QString" value="255,255,255,255"></Option>
-                    <Option name="spread" type="QString" value="2"></Option>
-                    <Option name="spread_unit" type="QString" value="MM"></Option>
-                    <Option name="spread_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="blend_mode" value="0" type="QString"/>
+                    <Option name="blur_level" value="2.645" type="QString"/>
+                    <Option name="blur_unit" value="MM" type="QString"/>
+                    <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color1" value="0,0,255,255" type="QString"/>
+                    <Option name="color2" value="0,255,0,255" type="QString"/>
+                    <Option name="color_type" value="0" type="QString"/>
+                    <Option name="direction" value="ccw" type="QString"/>
+                    <Option name="discrete" value="0" type="QString"/>
+                    <Option name="draw_mode" value="2" type="QString"/>
+                    <Option name="enabled" value="0" type="QString"/>
+                    <Option name="opacity" value="0.5" type="QString"/>
+                    <Option name="rampType" value="gradient" type="QString"/>
+                    <Option name="single_color" value="255,255,255,255" type="QString"/>
+                    <Option name="spec" value="rgb" type="QString"/>
+                    <Option name="spread" value="2" type="QString"/>
+                    <Option name="spread_unit" value="MM" type="QString"/>
+                    <Option name="spread_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
                   </Option>
-                  <prop k="blend_mode" v="0"></prop>
-                  <prop k="blur_level" v="2.645"></prop>
-                  <prop k="blur_unit" v="MM"></prop>
-                  <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="color1" v="0,0,255,255"></prop>
-                  <prop k="color2" v="0,255,0,255"></prop>
-                  <prop k="color_type" v="0"></prop>
-                  <prop k="discrete" v="0"></prop>
-                  <prop k="draw_mode" v="2"></prop>
-                  <prop k="enabled" v="0"></prop>
-                  <prop k="opacity" v="0.5"></prop>
-                  <prop k="rampType" v="gradient"></prop>
-                  <prop k="single_color" v="255,255,255,255"></prop>
-                  <prop k="spread" v="2"></prop>
-                  <prop k="spread_unit" v="MM"></prop>
-                  <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 </effect>
                 <effect type="drawSource">
                   <Option type="Map">
-                    <Option name="blend_mode" type="QString" value="0"></Option>
-                    <Option name="draw_mode" type="QString" value="2"></Option>
-                    <Option name="enabled" type="QString" value="1"></Option>
-                    <Option name="opacity" type="QString" value="1"></Option>
+                    <Option name="blend_mode" value="0" type="QString"/>
+                    <Option name="draw_mode" value="2" type="QString"/>
+                    <Option name="enabled" value="1" type="QString"/>
+                    <Option name="opacity" value="1" type="QString"/>
                   </Option>
-                  <prop k="blend_mode" v="0"></prop>
-                  <prop k="draw_mode" v="2"></prop>
-                  <prop k="enabled" v="1"></prop>
-                  <prop k="opacity" v="1"></prop>
                 </effect>
                 <effect type="innerShadow">
                   <Option type="Map">
-                    <Option name="blend_mode" type="QString" value="13"></Option>
-                    <Option name="blur_level" type="QString" value="2.645"></Option>
-                    <Option name="blur_unit" type="QString" value="MM"></Option>
-                    <Option name="blur_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                    <Option name="color" type="QString" value="0,0,0,255"></Option>
-                    <Option name="draw_mode" type="QString" value="2"></Option>
-                    <Option name="enabled" type="QString" value="0"></Option>
-                    <Option name="offset_angle" type="QString" value="135"></Option>
-                    <Option name="offset_distance" type="QString" value="2"></Option>
-                    <Option name="offset_unit" type="QString" value="MM"></Option>
-                    <Option name="offset_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                    <Option name="opacity" type="QString" value="1"></Option>
+                    <Option name="blend_mode" value="13" type="QString"/>
+                    <Option name="blur_level" value="2.645" type="QString"/>
+                    <Option name="blur_unit" value="MM" type="QString"/>
+                    <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color" value="0,0,0,255" type="QString"/>
+                    <Option name="draw_mode" value="2" type="QString"/>
+                    <Option name="enabled" value="0" type="QString"/>
+                    <Option name="offset_angle" value="135" type="QString"/>
+                    <Option name="offset_distance" value="2" type="QString"/>
+                    <Option name="offset_unit" value="MM" type="QString"/>
+                    <Option name="offset_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="opacity" value="1" type="QString"/>
                   </Option>
-                  <prop k="blend_mode" v="13"></prop>
-                  <prop k="blur_level" v="2.645"></prop>
-                  <prop k="blur_unit" v="MM"></prop>
-                  <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="color" v="0,0,0,255"></prop>
-                  <prop k="draw_mode" v="2"></prop>
-                  <prop k="enabled" v="0"></prop>
-                  <prop k="offset_angle" v="135"></prop>
-                  <prop k="offset_distance" v="2"></prop>
-                  <prop k="offset_unit" v="MM"></prop>
-                  <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="opacity" v="1"></prop>
                 </effect>
                 <effect type="innerGlow">
                   <Option type="Map">
-                    <Option name="blend_mode" type="QString" value="0"></Option>
-                    <Option name="blur_level" type="QString" value="2.645"></Option>
-                    <Option name="blur_unit" type="QString" value="MM"></Option>
-                    <Option name="blur_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                    <Option name="color1" type="QString" value="0,0,255,255"></Option>
-                    <Option name="color2" type="QString" value="0,255,0,255"></Option>
-                    <Option name="color_type" type="QString" value="0"></Option>
-                    <Option name="discrete" type="QString" value="0"></Option>
-                    <Option name="draw_mode" type="QString" value="2"></Option>
-                    <Option name="enabled" type="QString" value="0"></Option>
-                    <Option name="opacity" type="QString" value="0.5"></Option>
-                    <Option name="rampType" type="QString" value="gradient"></Option>
-                    <Option name="single_color" type="QString" value="255,255,255,255"></Option>
-                    <Option name="spread" type="QString" value="2"></Option>
-                    <Option name="spread_unit" type="QString" value="MM"></Option>
-                    <Option name="spread_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                    <Option name="blend_mode" value="0" type="QString"/>
+                    <Option name="blur_level" value="2.645" type="QString"/>
+                    <Option name="blur_unit" value="MM" type="QString"/>
+                    <Option name="blur_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                    <Option name="color1" value="0,0,255,255" type="QString"/>
+                    <Option name="color2" value="0,255,0,255" type="QString"/>
+                    <Option name="color_type" value="0" type="QString"/>
+                    <Option name="direction" value="ccw" type="QString"/>
+                    <Option name="discrete" value="0" type="QString"/>
+                    <Option name="draw_mode" value="2" type="QString"/>
+                    <Option name="enabled" value="0" type="QString"/>
+                    <Option name="opacity" value="0.5" type="QString"/>
+                    <Option name="rampType" value="gradient" type="QString"/>
+                    <Option name="single_color" value="255,255,255,255" type="QString"/>
+                    <Option name="spec" value="rgb" type="QString"/>
+                    <Option name="spread" value="2" type="QString"/>
+                    <Option name="spread_unit" value="MM" type="QString"/>
+                    <Option name="spread_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
                   </Option>
-                  <prop k="blend_mode" v="0"></prop>
-                  <prop k="blur_level" v="2.645"></prop>
-                  <prop k="blur_unit" v="MM"></prop>
-                  <prop k="blur_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                  <prop k="color1" v="0,0,255,255"></prop>
-                  <prop k="color2" v="0,255,0,255"></prop>
-                  <prop k="color_type" v="0"></prop>
-                  <prop k="discrete" v="0"></prop>
-                  <prop k="draw_mode" v="2"></prop>
-                  <prop k="enabled" v="0"></prop>
-                  <prop k="opacity" v="0.5"></prop>
-                  <prop k="rampType" v="gradient"></prop>
-                  <prop k="single_color" v="255,255,255,255"></prop>
-                  <prop k="spread" v="2"></prop>
-                  <prop k="spread_unit" v="MM"></prop>
-                  <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 </effect>
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties" type="Map">
                     <Option name="size" type="Map">
-                      <Option name="active" type="bool" value="true"></Option>
-                      <Option name="expression" type="QString" value="2 + randf(-1, 2)"></Option>
-                      <Option name="type" type="int" value="3"></Option>
+                      <Option name="active" value="true" type="bool"/>
+                      <Option name="expression" value="2 + randf(-1, 2)" type="QString"/>
+                      <Option name="type" value="3" type="int"/>
                     </Option>
                   </Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation></rotation>
-        <sizescale></sizescale>
+        <rotation/>
+        <sizescale/>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"/>
+      </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="OnConvertFormatRegeneratePrimaryKey" type="QString" value="false"></Option>
-          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
-          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
-          <Option name="variableNames" type="QString" value="quickosm_query"></Option>
-          <Option name="variableValues" type="QString" value="[out:xml] [timeout:25];&#xA;(&#xA;    node[&quot;natural&quot;=&quot;tree&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;natural&quot;=&quot;tree&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;natural&quot;=&quot;tree&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;);&#xA;(._;>;);&#xA;out body;"></Option>
+          <Option name="OnConvertFormatRegeneratePrimaryKey" value="false" type="QString"/>
+          <Option name="QFieldSync/action" value="offline" type="QString"/>
+          <Option name="QFieldSync/cloud_action" value="offline" type="QString"/>
+          <Option name="QFieldSync/photo_naming" value="{}" type="QString"/>
+          <Option name="embeddedWidgets/count" value="0" type="QString"/>
+          <Option name="variableNames" value="quickosm_query" type="QString"/>
+          <Option name="variableValues" value="[out:xml] [timeout:25];&#xa;(&#xa;    node[&quot;natural&quot;=&quot;tree&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;natural&quot;=&quot;tree&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;natural&quot;=&quot;tree&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;);&#xa;(._;>;);&#xa;out body;" type="QString"/>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="0" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="1" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="5" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
-          <attribute color="#000000" field="" label=""></attribute>
+        <DiagramCategory scaleDependency="Area" sizeType="MM" spacingUnit="MM" direction="0" height="15" rotationOffset="270" barWidth="5" scaleBasedVisibility="0" penColor="#000000" minimumSize="0" spacingUnitScale="3x:0,0,0,0,0,0" backgroundAlpha="255" showAxis="1" opacity="1" minScaleDenominator="0" penAlpha="255" width="15" enabled="0" penWidth="0" diagramOrientation="Up" spacing="5" lineSizeType="MM" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" backgroundColor="#ffffff" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0">
+          <fontProperties bold="0" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" underline="0" style="" strikethrough="0"/>
+          <attribute field="" color="#000000" label="" colorOpacity="1"/>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+            <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{165551f0-7e5e-461e-b859-7a0fe828dbbc}">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
-                  <Option name="capstyle" type="QString" value="square"></Option>
-                  <Option name="customdash" type="QString" value="5;2"></Option>
-                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="customdash_unit" type="QString" value="MM"></Option>
-                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
-                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
-                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
-                  <Option name="joinstyle" type="QString" value="bevel"></Option>
-                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
-                  <Option name="line_style" type="QString" value="solid"></Option>
-                  <Option name="line_width" type="QString" value="0.26"></Option>
-                  <Option name="line_width_unit" type="QString" value="MM"></Option>
-                  <Option name="offset" type="QString" value="0"></Option>
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="offset_unit" type="QString" value="MM"></Option>
-                  <Option name="ring_filter" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
-                  <Option name="trim_distance_start" type="QString" value="0"></Option>
-                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
-                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
-                  <Option name="use_custom_dash" type="QString" value="0"></Option>
-                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="align_dash_pattern" value="0" type="QString"/>
+                  <Option name="capstyle" value="square" type="QString"/>
+                  <Option name="customdash" value="5;2" type="QString"/>
+                  <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="customdash_unit" value="MM" type="QString"/>
+                  <Option name="dash_pattern_offset" value="0" type="QString"/>
+                  <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                  <Option name="draw_inside_polygon" value="0" type="QString"/>
+                  <Option name="joinstyle" value="bevel" type="QString"/>
+                  <Option name="line_color" value="35,35,35,255" type="QString"/>
+                  <Option name="line_style" value="solid" type="QString"/>
+                  <Option name="line_width" value="0.26" type="QString"/>
+                  <Option name="line_width_unit" value="MM" type="QString"/>
+                  <Option name="offset" value="0" type="QString"/>
+                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="offset_unit" value="MM" type="QString"/>
+                  <Option name="ring_filter" value="0" type="QString"/>
+                  <Option name="trim_distance_end" value="0" type="QString"/>
+                  <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                  <Option name="trim_distance_start" value="0" type="QString"/>
+                  <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                  <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                  <Option name="use_custom_dash" value="0" type="QString"/>
+                  <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
                 </Option>
-                <prop k="align_dash_pattern" v="0"></prop>
-                <prop k="capstyle" v="square"></prop>
-                <prop k="customdash" v="5;2"></prop>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="customdash_unit" v="MM"></prop>
-                <prop k="dash_pattern_offset" v="0"></prop>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="dash_pattern_offset_unit" v="MM"></prop>
-                <prop k="draw_inside_polygon" v="0"></prop>
-                <prop k="joinstyle" v="bevel"></prop>
-                <prop k="line_color" v="35,35,35,255"></prop>
-                <prop k="line_style" v="solid"></prop>
-                <prop k="line_width" v="0.26"></prop>
-                <prop k="line_width_unit" v="MM"></prop>
-                <prop k="offset" v="0"></prop>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="offset_unit" v="MM"></prop>
-                <prop k="ring_filter" v="0"></prop>
-                <prop k="trim_distance_end" v="0"></prop>
-                <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_end_unit" v="MM"></prop>
-                <prop k="trim_distance_start" v="0"></prop>
-                <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_start_unit" v="MM"></prop>
-                <prop k="tweak_dash_pattern_on_corners" v="0"></prop>
-                <prop k="use_custom_dash" v="0"></prop>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value=""></Option>
-                    <Option name="properties"></Option>
-                    <Option name="type" type="QString" value="collection"></Option>
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -2147,152 +2470,161 @@ def my_form_open(dialog, layer, feature):
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="0" priority="0" showAll="1" zIndex="0">
+      <DiagramLayerSettings priority="0" dist="0" showAll="1" linePlacementFlags="18" obstacle="0" placement="0" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""></Option>
-            <Option name="properties"></Option>
-            <Option name="type" type="QString" value="collection"></Option>
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks></activeChecks>
-        <checkConfiguration></checkConfiguration>
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+        <activeChecks/>
+        <checkConfiguration/>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"></legend>
-      <referencedLayers></referencedLayers>
+      <legend showLabelLegend="0" type="default-vector"/>
+      <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="full_id">
+        <field configurationFlags="NoFlag" name="full_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_id">
+        <field configurationFlags="NoFlag" name="osm_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_type">
+        <field configurationFlags="NoFlag" name="osm_type">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="height">
+        <field configurationFlags="NoFlag" name="height">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="leaf_type">
+        <field configurationFlags="NoFlag" name="leaf_type">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="genus">
+        <field configurationFlags="NoFlag" name="genus">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""></alias>
-        <alias field="full_id" index="1" name=""></alias>
-        <alias field="osm_id" index="2" name=""></alias>
-        <alias field="osm_type" index="3" name=""></alias>
-        <alias field="height" index="4" name=""></alias>
-        <alias field="leaf_type" index="5" name=""></alias>
-        <alias field="genus" index="6" name=""></alias>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="full_id" index="1"/>
+        <alias name="" field="osm_id" index="2"/>
+        <alias name="" field="osm_type" index="3"/>
+        <alias name="" field="height" index="4"/>
+        <alias name="" field="leaf_type" index="5"/>
+        <alias name="" field="genus" index="6"/>
       </aliases>
+      <splitPolicies>
+        <policy field="id" policy="Duplicate"/>
+        <policy field="full_id" policy="Duplicate"/>
+        <policy field="osm_id" policy="Duplicate"/>
+        <policy field="osm_type" policy="Duplicate"/>
+        <policy field="height" policy="Duplicate"/>
+        <policy field="leaf_type" policy="Duplicate"/>
+        <policy field="genus" policy="Duplicate"/>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="id"></default>
-        <default applyOnUpdate="0" expression="" field="full_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_type"></default>
-        <default applyOnUpdate="0" expression="" field="height"></default>
-        <default applyOnUpdate="0" expression="" field="leaf_type"></default>
-        <default applyOnUpdate="0" expression="" field="genus"></default>
+        <default field="id" applyOnUpdate="0" expression=""/>
+        <default field="full_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_type" applyOnUpdate="0" expression=""/>
+        <default field="height" applyOnUpdate="0" expression=""/>
+        <default field="leaf_type" applyOnUpdate="0" expression=""/>
+        <default field="genus" applyOnUpdate="0" expression=""/>
       </defaults>
       <constraints>
-        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
-        <constraint constraints="0" exp_strength="0" field="full_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_type" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="height" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="leaf_type" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="genus" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint notnull_strength="1" field="id" unique_strength="1" constraints="3" exp_strength="0"/>
+        <constraint notnull_strength="0" field="full_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_type" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="height" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="leaf_type" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="genus" unique_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"></constraint>
-        <constraint desc="" exp="" field="full_id"></constraint>
-        <constraint desc="" exp="" field="osm_id"></constraint>
-        <constraint desc="" exp="" field="osm_type"></constraint>
-        <constraint desc="" exp="" field="height"></constraint>
-        <constraint desc="" exp="" field="leaf_type"></constraint>
-        <constraint desc="" exp="" field="genus"></constraint>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="full_id" exp=""/>
+        <constraint desc="" field="osm_id" exp=""/>
+        <constraint desc="" field="osm_type" exp=""/>
+        <constraint desc="" field="height" exp=""/>
+        <constraint desc="" field="leaf_type" exp=""/>
+        <constraint desc="" field="genus" exp=""/>
       </constraintExpressions>
-      <expressionfields></expressionfields>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
-        <actionsetting action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" capture="0" icon="" id="{3020291c-112f-4faf-8a8e-4d822aed7a70}" isEnabledOnlyWhenEditable="0" name="OpenStreetMap Browser" notificationMessage="" shortTitle="OpenStreetMap Browser" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <actionsetting notificationMessage="" name="OpenStreetMap Browser" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" shortTitle="OpenStreetMap Browser" icon="" id="{3020291c-112f-4faf-8a8e-4d822aed7a70}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{e6215f53-dfe0-4653-93ba-7d77c166ed05}" isEnabledOnlyWhenEditable="0" name="JOSM" notificationMessage="" shortTitle="JOSM" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="JOSM" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" shortTitle="JOSM" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{e6215f53-dfe0-4653-93ba-7d77c166ed05}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" capture="0" icon="" id="{ba237b80-40d1-43bd-bd2c-e3e7a38ac642}" isEnabledOnlyWhenEditable="0" name="User default editor" notificationMessage="" shortTitle="User default editor" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="User default editor" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" shortTitle="User default editor" icon="" id="{ba237b80-40d1-43bd-bd2c-e3e7a38ac642}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Trees&quot;)" capture="0" icon="" id="{e28de84e-1834-44c2-8c0a-8ebb03145850}" isEnabledOnlyWhenEditable="0" name="Reload the query in a new file" notificationMessage="" shortTitle="Reload the query in a new file" type="1">
-          <actionScope id="Layer"></actionScope>
+        <actionsetting notificationMessage="" name="Reload the query in a new file" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Trees&quot;)" shortTitle="Reload the query in a new file" icon="" id="{e28de84e-1834-44c2-8c0a-8ebb03145850}">
+          <actionScope id="Layer"/>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
         <columns>
-          <column hidden="0" name="full_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_type" type="field" width="-1"></column>
-          <column hidden="0" name="height" type="field" width="-1"></column>
-          <column hidden="0" name="leaf_type" type="field" width="-1"></column>
-          <column hidden="0" name="genus" type="field" width="-1"></column>
-          <column hidden="1" type="actions" width="-1"></column>
-          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column name="full_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_type" hidden="0" type="field" width="-1"/>
+          <column name="height" hidden="0" type="field" width="-1"/>
+          <column name="leaf_type" hidden="0" type="field" width="-1"/>
+          <column name="genus" hidden="0" type="field" width="-1"/>
+          <column hidden="1" type="actions" width="-1"/>
+          <column name="id" hidden="0" type="field" width="-1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles></rowstyles>
-        <fieldstyles></fieldstyles>
+        <rowstyles/>
+        <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions></storedexpressions>
+      <storedexpressions/>
       <editform tolerant="1"></editform>
-      <editforminit></editforminit>
+      <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode># -*- coding: utf-8 -*-
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -2308,36 +2640,36 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-</editforminitcode>
+]]></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="full_id"></field>
-        <field editable="1" name="genus"></field>
-        <field editable="1" name="height"></field>
-        <field editable="1" name="id"></field>
-        <field editable="1" name="leaf_type"></field>
-        <field editable="1" name="natural"></field>
-        <field editable="1" name="osm_id"></field>
-        <field editable="1" name="osm_type"></field>
+        <field name="full_id" editable="1"/>
+        <field name="genus" editable="1"/>
+        <field name="height" editable="1"/>
+        <field name="id" editable="1"/>
+        <field name="leaf_type" editable="1"/>
+        <field name="natural" editable="1"/>
+        <field name="osm_id" editable="1"/>
+        <field name="osm_type" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="full_id"></field>
-        <field labelOnTop="0" name="genus"></field>
-        <field labelOnTop="0" name="height"></field>
-        <field labelOnTop="0" name="id"></field>
-        <field labelOnTop="0" name="leaf_type"></field>
-        <field labelOnTop="0" name="natural"></field>
-        <field labelOnTop="0" name="osm_id"></field>
-        <field labelOnTop="0" name="osm_type"></field>
+        <field name="full_id" labelOnTop="0"/>
+        <field name="genus" labelOnTop="0"/>
+        <field name="height" labelOnTop="0"/>
+        <field name="id" labelOnTop="0"/>
+        <field name="leaf_type" labelOnTop="0"/>
+        <field name="natural" labelOnTop="0"/>
+        <field name="osm_id" labelOnTop="0"/>
+        <field name="osm_type" labelOnTop="0"/>
       </labelOnTop>
-      <reuseLastValue></reuseLastValue>
-      <dataDefinedFieldProperties></dataDefinedFieldProperties>
-      <widgets></widgets>
+      <reuseLastValue/>
+      <dataDefinedFieldProperties/>
+      <widgets/>
       <previewExpression>"full_id"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
-    <maplayer autoRefreshEnabled="0" autoRefreshTime="0" geometry="Polygon" hasScaleBasedVisibilityFlag="0" labelsEnabled="0" legendPlaceholderImage="" maxScale="0" minScale="100000000" readOnly="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyAlgorithm="0" simplifyDrawingHints="1" simplifyDrawingTol="1" simplifyLocal="1" simplifyMaxScale="1" styleCategories="AllStyleCategories" symbologyReferenceScale="-1" type="vector" wkbType="MultiPolygon">
+    <maplayer autoRefreshMode="Disabled" simplifyAlgorithm="0" minScale="100000000" simplifyLocal="1" legendPlaceholderImage="" readOnly="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="1" refreshOnNotifyMessage="" maxScale="0" autoRefreshTime="0" wkbType="MultiPolygon" simplifyMaxScale="1" geometry="Polygon" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" type="vector" simplifyDrawingTol="1" symbologyReferenceScale="-1" labelsEnabled="0">
       <extent>
         <xmin>3.86999799999999983</xmin>
         <ymin>43.61234089999999952</ymin>
@@ -2357,8 +2689,8 @@ def my_form_open(dialog, layer, feature):
       </keywordList>
       <layername>water_surfaces</layername>
       <srs>
-        <spatialrefsys>
-          <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <spatialrefsys nativeFormat="Wkt">
+          <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
           <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
           <srsid>3452</srsid>
           <srid>4326</srid>
@@ -2385,12 +2717,13 @@ def my_form_open(dialog, layer, feature):
           <email></email>
           <role></role>
         </contact>
-        <links></links>
+        <links/>
+        <dates/>
         <fees></fees>
         <encoding></encoding>
         <crs>
-          <spatialrefsys>
-            <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+          <spatialrefsys nativeFormat="Wkt">
+            <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
             <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
             <srsid>3452</srsid>
             <srid>4326</srid>
@@ -2402,7 +2735,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial crs="EPSG:4326" dimensions="2" maxx="0" maxy="0" maxz="0" minx="0" miny="0" minz="0"></spatial>
+          <spatial minz="0" maxx="0" maxy="0" crs="EPSG:4326" minx="0" dimensions="2" miny="0" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -2412,164 +2745,261 @@ def my_form_open(dialog, layer, feature):
         </extent>
       </resourceMetadata>
       <provider encoding="">postgres</provider>
-      <vectorjoins></vectorjoins>
-      <layerDependencies></layerDependencies>
-      <dataDependencies></dataDependencies>
-      <expressionfields></expressionfields>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
       <map-layer-style-manager current="default">
-        <map-layer-style name="default"></map-layer-style>
+        <map-layer-style name="default"/>
       </map-layer-style-manager>
-      <auxiliaryLayer></auxiliaryLayer>
-      <metadataUrls></metadataUrls>
+      <auxiliaryLayer/>
+      <metadataUrls/>
       <flags>
         <Identifiable>1</Identifiable>
         <Removable>1</Removable>
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal accumulate="0" durationField="" durationUnit="min" enabled="0" endExpression="" endField="" fixedDuration="0" limitMode="0" mode="0" startExpression="" startField="">
+      <temporal startField="" accumulate="0" endField="" limitMode="0" durationUnit="min" enabled="0" fixedDuration="0" mode="0" durationField="" endExpression="" startExpression="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <renderer-v2 enableorderby="0" forceraster="0" referencescale="-1" symbollevels="0" type="singleSymbol">
-        <symbols>
-          <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="0" type="fill">
+      <elevation zoffset="0" respectLayerSymbol="1" extrusion="0" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" type="IndividualFeatures" zscale="1" binding="Centroid" extrusionEnabled="0">
+        <data-defined-properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data-defined-properties>
+        <profileLineSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""></Option>
-                <Option name="properties"></Option>
-                <Option name="type" type="QString" value="collection"></Option>
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{cb34c5a1-4e2d-4ff7-b20d-47bc7729c7d0}">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="color" type="QString" value="165,191,221,255"></Option>
-                <Option name="joinstyle" type="QString" value="bevel"></Option>
-                <Option name="offset" type="QString" value="0,0"></Option>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                <Option name="offset_unit" type="QString" value="MM"></Option>
-                <Option name="outline_color" type="QString" value="100,152,210,255"></Option>
-                <Option name="outline_style" type="QString" value="solid"></Option>
-                <Option name="outline_width" type="QString" value="0.26"></Option>
-                <Option name="outline_width_unit" type="QString" value="MM"></Option>
-                <Option name="style" type="QString" value="solid"></Option>
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="square" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="line_color" value="145,82,45,255" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.6" type="QString"/>
+                <Option name="line_width_unit" value="MM" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
-              <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="color" v="165,191,221,255"></prop>
-              <prop k="joinstyle" v="bevel"></prop>
-              <prop k="offset" v="0,0"></prop>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-              <prop k="offset_unit" v="MM"></prop>
-              <prop k="outline_color" v="100,152,210,255"></prop>
-              <prop k="outline_style" v="solid"></prop>
-              <prop k="outline_width" v="0.26"></prop>
-              <prop k="outline_width_unit" v="MM"></prop>
-              <prop k="style" v="solid"></prop>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileLineSymbol>
+        <profileFillSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{edbe41f7-6d03-4526-88e5-8e79f8544ac4}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="145,82,45,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="104,59,32,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileFillSymbol>
+        <profileMarkerSymbol>
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{7f832911-c8d7-47cc-a05e-6f1f2039674c}">
+              <Option type="Map">
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="145,82,45,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="diamond" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="104,59,32,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="3" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MM" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </profileMarkerSymbol>
+      </elevation>
+      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
+        <symbols>
+          <symbol clip_to_extent="1" name="0" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{332d3749-791b-40d1-8112-8a24c7094f43}">
+              <Option type="Map">
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="165,191,221,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="100,152,210,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.26" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </symbols>
-        <rotation></rotation>
-        <sizescale></sizescale>
+        <rotation/>
+        <sizescale/>
       </renderer-v2>
+      <selection mode="Default">
+        <selectionColor invalid="1"/>
+      </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="OnConvertFormatRegeneratePrimaryKey" type="QString" value="false"></Option>
-          <Option name="QFieldSync/action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/cloud_action" type="QString" value="offline"></Option>
-          <Option name="QFieldSync/photo_naming" type="QString" value="{}"></Option>
-          <Option name="embeddedWidgets/count" type="QString" value="0"></Option>
-          <Option name="variableNames" type="QString" value="quickosm_query"></Option>
-          <Option name="variableValues" type="QString" value="[out:xml] [timeout:25];&#xA;(&#xA;    node[&quot;natural&quot;=&quot;water&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    node[&quot;landuse&quot;=&quot;basin&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    node[&quot;landuse&quot;=&quot;reservoir&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    node[&quot;landuse&quot;=&quot;salt_pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    node[&quot;pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;natural&quot;=&quot;water&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;landuse&quot;=&quot;basin&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;landuse&quot;=&quot;reservoir&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;landuse&quot;=&quot;salt_pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    way[&quot;pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;natural&quot;=&quot;water&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;landuse&quot;=&quot;basin&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;landuse&quot;=&quot;reservoir&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;landuse&quot;=&quot;salt_pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;    relation[&quot;pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xA;);&#xA;(._;>;);&#xA;out body;"></Option>
+          <Option name="OnConvertFormatRegeneratePrimaryKey" value="false" type="QString"/>
+          <Option name="QFieldSync/action" value="offline" type="QString"/>
+          <Option name="QFieldSync/cloud_action" value="offline" type="QString"/>
+          <Option name="QFieldSync/photo_naming" value="{}" type="QString"/>
+          <Option name="embeddedWidgets/count" value="0" type="QString"/>
+          <Option name="variableNames" value="quickosm_query" type="QString"/>
+          <Option name="variableValues" value="[out:xml] [timeout:25];&#xa;(&#xa;    node[&quot;natural&quot;=&quot;water&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    node[&quot;landuse&quot;=&quot;basin&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    node[&quot;landuse&quot;=&quot;reservoir&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    node[&quot;landuse&quot;=&quot;salt_pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    node[&quot;pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;natural&quot;=&quot;water&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;landuse&quot;=&quot;basin&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;landuse&quot;=&quot;reservoir&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;landuse&quot;=&quot;salt_pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    way[&quot;pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;natural&quot;=&quot;water&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;landuse&quot;=&quot;basin&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;landuse&quot;=&quot;reservoir&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;landuse&quot;=&quot;salt_pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;    relation[&quot;pond&quot;]( 43.61225,3.86993,43.61601,3.87395);&#xa;);&#xa;(._;>;);&#xa;out body;" type="QString"/>
         </Option>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-        <DiagramCategory backgroundAlpha="255" backgroundColor="#ffffff" barWidth="5" diagramOrientation="Up" direction="0" enabled="0" height="15" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0" lineSizeType="MM" maxScaleDenominator="1e+08" minScaleDenominator="0" minimumSize="0" opacity="1" penAlpha="255" penColor="#000000" penWidth="0" rotationOffset="270" scaleBasedVisibility="0" scaleDependency="Area" showAxis="1" sizeScale="3x:0,0,0,0,0,0" sizeType="MM" spacing="5" spacingUnit="MM" spacingUnitScale="3x:0,0,0,0,0,0" width="15">
-          <fontProperties description="Ubuntu,11,-1,5,50,0,0,0,0,0" style=""></fontProperties>
-          <attribute color="#000000" field="" label=""></attribute>
+        <DiagramCategory scaleDependency="Area" sizeType="MM" spacingUnit="MM" direction="0" height="15" rotationOffset="270" barWidth="5" scaleBasedVisibility="0" penColor="#000000" minimumSize="0" spacingUnitScale="3x:0,0,0,0,0,0" backgroundAlpha="255" showAxis="1" opacity="1" minScaleDenominator="0" penAlpha="255" width="15" enabled="0" penWidth="0" diagramOrientation="Up" spacing="5" lineSizeType="MM" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" backgroundColor="#ffffff" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0">
+          <fontProperties bold="0" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" underline="0" style="" strikethrough="0"/>
+          <attribute field="" color="#000000" label="" colorOpacity="1"/>
           <axisSymbol>
-            <symbol alpha="1" clip_to_extent="1" force_rhr="0" name="" type="line">
+            <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""></Option>
-                  <Option name="properties"></Option>
-                  <Option name="type" type="QString" value="collection"></Option>
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+              <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{8daf6784-48a1-4847-ae17-a473a3c3082f}">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" type="QString" value="0"></Option>
-                  <Option name="capstyle" type="QString" value="square"></Option>
-                  <Option name="customdash" type="QString" value="5;2"></Option>
-                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="customdash_unit" type="QString" value="MM"></Option>
-                  <Option name="dash_pattern_offset" type="QString" value="0"></Option>
-                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"></Option>
-                  <Option name="draw_inside_polygon" type="QString" value="0"></Option>
-                  <Option name="joinstyle" type="QString" value="bevel"></Option>
-                  <Option name="line_color" type="QString" value="35,35,35,255"></Option>
-                  <Option name="line_style" type="QString" value="solid"></Option>
-                  <Option name="line_width" type="QString" value="0.26"></Option>
-                  <Option name="line_width_unit" type="QString" value="MM"></Option>
-                  <Option name="offset" type="QString" value="0"></Option>
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="offset_unit" type="QString" value="MM"></Option>
-                  <Option name="ring_filter" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end" type="QString" value="0"></Option>
-                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_end_unit" type="QString" value="MM"></Option>
-                  <Option name="trim_distance_start" type="QString" value="0"></Option>
-                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
-                  <Option name="trim_distance_start_unit" type="QString" value="MM"></Option>
-                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"></Option>
-                  <Option name="use_custom_dash" type="QString" value="0"></Option>
-                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"></Option>
+                  <Option name="align_dash_pattern" value="0" type="QString"/>
+                  <Option name="capstyle" value="square" type="QString"/>
+                  <Option name="customdash" value="5;2" type="QString"/>
+                  <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="customdash_unit" value="MM" type="QString"/>
+                  <Option name="dash_pattern_offset" value="0" type="QString"/>
+                  <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                  <Option name="draw_inside_polygon" value="0" type="QString"/>
+                  <Option name="joinstyle" value="bevel" type="QString"/>
+                  <Option name="line_color" value="35,35,35,255" type="QString"/>
+                  <Option name="line_style" value="solid" type="QString"/>
+                  <Option name="line_width" value="0.26" type="QString"/>
+                  <Option name="line_width_unit" value="MM" type="QString"/>
+                  <Option name="offset" value="0" type="QString"/>
+                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="offset_unit" value="MM" type="QString"/>
+                  <Option name="ring_filter" value="0" type="QString"/>
+                  <Option name="trim_distance_end" value="0" type="QString"/>
+                  <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                  <Option name="trim_distance_start" value="0" type="QString"/>
+                  <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                  <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                  <Option name="use_custom_dash" value="0" type="QString"/>
+                  <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
                 </Option>
-                <prop k="align_dash_pattern" v="0"></prop>
-                <prop k="capstyle" v="square"></prop>
-                <prop k="customdash" v="5;2"></prop>
-                <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="customdash_unit" v="MM"></prop>
-                <prop k="dash_pattern_offset" v="0"></prop>
-                <prop k="dash_pattern_offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="dash_pattern_offset_unit" v="MM"></prop>
-                <prop k="draw_inside_polygon" v="0"></prop>
-                <prop k="joinstyle" v="bevel"></prop>
-                <prop k="line_color" v="35,35,35,255"></prop>
-                <prop k="line_style" v="solid"></prop>
-                <prop k="line_width" v="0.26"></prop>
-                <prop k="line_width_unit" v="MM"></prop>
-                <prop k="offset" v="0"></prop>
-                <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="offset_unit" v="MM"></prop>
-                <prop k="ring_filter" v="0"></prop>
-                <prop k="trim_distance_end" v="0"></prop>
-                <prop k="trim_distance_end_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_end_unit" v="MM"></prop>
-                <prop k="trim_distance_start" v="0"></prop>
-                <prop k="trim_distance_start_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
-                <prop k="trim_distance_start_unit" v="MM"></prop>
-                <prop k="tweak_dash_pattern_on_corners" v="0"></prop>
-                <prop k="use_custom_dash" v="0"></prop>
-                <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"></prop>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value=""></Option>
-                    <Option name="properties"></Option>
-                    <Option name="type" type="QString" value="collection"></Option>
+                    <Option name="name" value="" type="QString"/>
+                    <Option name="properties"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -2577,146 +3007,154 @@ def my_form_open(dialog, layer, feature):
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings dist="0" linePlacementFlags="18" obstacle="0" placement="1" priority="0" showAll="1" zIndex="0">
+      <DiagramLayerSettings priority="0" dist="0" showAll="1" linePlacementFlags="18" obstacle="0" placement="1" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""></Option>
-            <Option name="properties"></Option>
-            <Option name="type" type="QString" value="collection"></Option>
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
-        <activeChecks></activeChecks>
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+        <activeChecks/>
         <checkConfiguration type="Map">
           <Option name="QgsGeometryGapCheck" type="Map">
-            <Option name="allowedGapsBuffer" type="double" value="0"></Option>
-            <Option name="allowedGapsEnabled" type="bool" value="false"></Option>
-            <Option name="allowedGapsLayer" type="QString" value=""></Option>
+            <Option name="allowedGapsBuffer" value="0" type="double"/>
+            <Option name="allowedGapsEnabled" value="false" type="bool"/>
+            <Option name="allowedGapsLayer" value="" type="QString"/>
           </Option>
         </checkConfiguration>
       </geometryOptions>
-      <legend showLabelLegend="0" type="default-vector"></legend>
-      <referencedLayers></referencedLayers>
+      <legend showLabelLegend="0" type="default-vector"/>
+      <referencedLayers/>
       <fieldConfiguration>
-        <field configurationFlags="None" name="id">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="full_id">
+        <field configurationFlags="NoFlag" name="full_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_id">
+        <field configurationFlags="NoFlag" name="osm_id">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="osm_type">
+        <field configurationFlags="NoFlag" name="osm_type">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="natural">
+        <field configurationFlags="NoFlag" name="natural">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
-        <field configurationFlags="None" name="landuse">
+        <field configurationFlags="NoFlag" name="landuse">
           <editWidget type="TextEdit">
             <config>
-              <Option></Option>
+              <Option/>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""></alias>
-        <alias field="full_id" index="1" name=""></alias>
-        <alias field="osm_id" index="2" name=""></alias>
-        <alias field="osm_type" index="3" name=""></alias>
-        <alias field="natural" index="4" name=""></alias>
-        <alias field="landuse" index="5" name=""></alias>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="full_id" index="1"/>
+        <alias name="" field="osm_id" index="2"/>
+        <alias name="" field="osm_type" index="3"/>
+        <alias name="" field="natural" index="4"/>
+        <alias name="" field="landuse" index="5"/>
       </aliases>
+      <splitPolicies>
+        <policy field="id" policy="Duplicate"/>
+        <policy field="full_id" policy="Duplicate"/>
+        <policy field="osm_id" policy="Duplicate"/>
+        <policy field="osm_type" policy="Duplicate"/>
+        <policy field="natural" policy="Duplicate"/>
+        <policy field="landuse" policy="Duplicate"/>
+      </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="id"></default>
-        <default applyOnUpdate="0" expression="" field="full_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_id"></default>
-        <default applyOnUpdate="0" expression="" field="osm_type"></default>
-        <default applyOnUpdate="0" expression="" field="natural"></default>
-        <default applyOnUpdate="0" expression="" field="landuse"></default>
+        <default field="id" applyOnUpdate="0" expression=""/>
+        <default field="full_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_id" applyOnUpdate="0" expression=""/>
+        <default field="osm_type" applyOnUpdate="0" expression=""/>
+        <default field="natural" applyOnUpdate="0" expression=""/>
+        <default field="landuse" applyOnUpdate="0" expression=""/>
       </defaults>
       <constraints>
-        <constraint constraints="3" exp_strength="0" field="id" notnull_strength="1" unique_strength="1"></constraint>
-        <constraint constraints="0" exp_strength="0" field="full_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_id" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="osm_type" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="natural" notnull_strength="0" unique_strength="0"></constraint>
-        <constraint constraints="0" exp_strength="0" field="landuse" notnull_strength="0" unique_strength="0"></constraint>
+        <constraint notnull_strength="1" field="id" unique_strength="1" constraints="3" exp_strength="0"/>
+        <constraint notnull_strength="0" field="full_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="osm_type" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="natural" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="landuse" unique_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint desc="" exp="" field="id"></constraint>
-        <constraint desc="" exp="" field="full_id"></constraint>
-        <constraint desc="" exp="" field="osm_id"></constraint>
-        <constraint desc="" exp="" field="osm_type"></constraint>
-        <constraint desc="" exp="" field="natural"></constraint>
-        <constraint desc="" exp="" field="landuse"></constraint>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="full_id" exp=""/>
+        <constraint desc="" field="osm_id" exp=""/>
+        <constraint desc="" field="osm_type" exp=""/>
+        <constraint desc="" field="natural" exp=""/>
+        <constraint desc="" field="landuse" exp=""/>
       </constraintExpressions>
-      <expressionfields></expressionfields>
+      <expressionfields/>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"></defaultAction>
-        <actionsetting action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" capture="0" icon="" id="{ba58ae00-921c-4019-ace7-53cda904d301}" isEnabledOnlyWhenEditable="0" name="OpenStreetMap Browser" notificationMessage="" shortTitle="OpenStreetMap Browser" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <actionsetting notificationMessage="" name="OpenStreetMap Browser" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/browse/[% &quot;osm_type&quot; %]/[% &quot;osm_id&quot; %]" shortTitle="OpenStreetMap Browser" icon="" id="{ba58ae00-921c-4019-ace7-53cda904d301}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" capture="0" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{067eb127-621b-414f-8ee7-ab1de422f258}" isEnabledOnlyWhenEditable="0" name="JOSM" notificationMessage="" shortTitle="JOSM" type="1">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="JOSM" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run(&quot;josm&quot;,&quot;[% &quot;full_id&quot; %]&quot;)" shortTitle="JOSM" icon="/home/mdouchin/.local/share/QGIS/QGIS3/profiles/default/python/plugins/QuickOSM/resources/icons/josm_icon.svg" id="{067eb127-621b-414f-8ee7-ab1de422f258}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" capture="0" icon="" id="{45c93ea8-e91d-4155-be1a-81a6f35318e0}" isEnabledOnlyWhenEditable="0" name="User default editor" notificationMessage="" shortTitle="User default editor" type="5">
-          <actionScope id="Feature"></actionScope>
-          <actionScope id="Canvas"></actionScope>
-          <actionScope id="Field"></actionScope>
+        <actionsetting notificationMessage="" name="User default editor" type="5" isEnabledOnlyWhenEditable="0" capture="0" action="http://www.openstreetmap.org/edit?[% &quot;osm_type&quot; %]=[% &quot;osm_id&quot; %]" shortTitle="User default editor" icon="" id="{45c93ea8-e91d-4155-be1a-81a6f35318e0}">
+          <actionScope id="Feature"/>
+          <actionScope id="Canvas"/>
+          <actionScope id="Field"/>
         </actionsetting>
-        <actionsetting action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Water surface&quot;)" capture="0" icon="" id="{2bc99ee6-3d50-4f23-a922-bc70ed01eb95}" isEnabledOnlyWhenEditable="0" name="Reload the query in a new file" notificationMessage="" shortTitle="Reload the query in a new file" type="1">
-          <actionScope id="Layer"></actionScope>
+        <actionsetting notificationMessage="" name="Reload the query in a new file" type="1" isEnabledOnlyWhenEditable="0" capture="0" action="from QuickOSM.core.actions import Actions;Actions.run_reload(layer_name=&quot;Water surface&quot;)" shortTitle="Reload the query in a new file" icon="" id="{2bc99ee6-3d50-4f23-a922-bc70ed01eb95}">
+          <actionScope id="Layer"/>
         </actionsetting>
       </attributeactions>
-      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
         <columns>
-          <column hidden="0" name="full_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_id" type="field" width="-1"></column>
-          <column hidden="0" name="osm_type" type="field" width="-1"></column>
-          <column hidden="0" name="landuse" type="field" width="-1"></column>
-          <column hidden="0" name="natural" type="field" width="-1"></column>
-          <column hidden="1" type="actions" width="-1"></column>
-          <column hidden="0" name="id" type="field" width="-1"></column>
+          <column name="full_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_id" hidden="0" type="field" width="-1"/>
+          <column name="osm_type" hidden="0" type="field" width="-1"/>
+          <column name="landuse" hidden="0" type="field" width="-1"/>
+          <column name="natural" hidden="0" type="field" width="-1"/>
+          <column hidden="1" type="actions" width="-1"/>
+          <column name="id" hidden="0" type="field" width="-1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
-        <rowstyles></rowstyles>
-        <fieldstyles></fieldstyles>
+        <rowstyles/>
+        <fieldstyles/>
       </conditionalstyles>
-      <storedexpressions></storedexpressions>
+      <storedexpressions/>
       <editform tolerant="1"></editform>
-      <editforminit></editforminit>
+      <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
-      <editforminitcode># -*- coding: utf-8 -*-
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
 """
 QGIS forms can have a Python function that is called when the form is
 opened.
@@ -2732,52 +3170,45 @@ from qgis.PyQt.QtWidgets import QWidget
 def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget, "MyLineEdit")
-</editforminitcode>
+]]></editforminitcode>
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="boat"></field>
-        <field editable="1" name="full_id"></field>
-        <field editable="1" name="id"></field>
-        <field editable="1" name="landuse"></field>
-        <field editable="1" name="natural"></field>
-        <field editable="1" name="osm_id"></field>
-        <field editable="1" name="osm_type"></field>
-        <field editable="1" name="water"></field>
+        <field name="boat" editable="1"/>
+        <field name="full_id" editable="1"/>
+        <field name="id" editable="1"/>
+        <field name="landuse" editable="1"/>
+        <field name="natural" editable="1"/>
+        <field name="osm_id" editable="1"/>
+        <field name="osm_type" editable="1"/>
+        <field name="water" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="boat"></field>
-        <field labelOnTop="0" name="full_id"></field>
-        <field labelOnTop="0" name="id"></field>
-        <field labelOnTop="0" name="landuse"></field>
-        <field labelOnTop="0" name="natural"></field>
-        <field labelOnTop="0" name="osm_id"></field>
-        <field labelOnTop="0" name="osm_type"></field>
-        <field labelOnTop="0" name="water"></field>
+        <field name="boat" labelOnTop="0"/>
+        <field name="full_id" labelOnTop="0"/>
+        <field name="id" labelOnTop="0"/>
+        <field name="landuse" labelOnTop="0"/>
+        <field name="natural" labelOnTop="0"/>
+        <field name="osm_id" labelOnTop="0"/>
+        <field name="osm_type" labelOnTop="0"/>
+        <field name="water" labelOnTop="0"/>
       </labelOnTop>
-      <reuseLastValue></reuseLastValue>
-      <dataDefinedFieldProperties></dataDefinedFieldProperties>
-      <widgets></widgets>
+      <reuseLastValue/>
+      <dataDefinedFieldProperties/>
+      <widgets/>
       <previewExpression>"full_id"</previewExpression>
-      <mapTip></mapTip>
+      <mapTip enabled="1"></mapTip>
     </maplayer>
   </projectlayers>
   <layerorder>
-    <layer id="water_surfaces_35b3563f_9a32_4576_b96e_1b455e15c1dd"></layer>
-    <layer id="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9"></layer>
-    <layer id="gardens_ea39c3a4_40ed_42cc_bfc6_6f9543cd7bec"></layer>
-    <layer id="footways_50464328_c5b5_4f2b_9bd0_0e4994ec17d5"></layer>
-    <layer id="buildings_684162e1_2d79_4556_84ea_d58bab657395"></layer>
+    <layer id="water_surfaces_35b3563f_9a32_4576_b96e_1b455e15c1dd"/>
+    <layer id="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9"/>
+    <layer id="gardens_ea39c3a4_40ed_42cc_bfc6_6f9543cd7bec"/>
+    <layer id="footways_50464328_c5b5_4f2b_9bd0_0e4994ec17d5"/>
+    <layer id="buildings_684162e1_2d79_4556_84ea_d58bab657395"/>
   </layerorder>
   <properties>
-    <DefaultStyles>
-      <ColorRamp type="QString"></ColorRamp>
-      <Fill type="QString"></Fill>
-      <Line type="QString"></Line>
-      <Marker type="QString"></Marker>
-      <Opacity type="double">1</Opacity>
-      <RandomColors type="bool">true</RandomColors>
-    </DefaultStyles>
+    <DefaultStyles/>
     <Digitizing>
       <AvoidIntersectionsMode type="int">0</AvoidIntersectionsMode>
     </Digitizing>
@@ -2810,6 +3241,7 @@ def my_form_open(dialog, layer, feature):
     <PAL>
       <CandidatesLinePerCM type="double">5</CandidatesLinePerCM>
       <CandidatesPolygonPerCM type="double">2.5</CandidatesPolygonPerCM>
+      <DrawLabelMetrics type="bool">false</DrawLabelMetrics>
       <DrawRectOnly type="bool">false</DrawRectOnly>
       <DrawUnplaced type="bool">false</DrawUnplaced>
       <PlacementEngineVersion type="int">1</PlacementEngineVersion>
@@ -2847,16 +3279,17 @@ def my_form_open(dialog, layer, feature):
         <value></value>
       </variableValues>
     </Variables>
-    <WCSLayers type="QStringList"></WCSLayers>
+    <WCSLayers type="QStringList"/>
     <WCSUrl type="QString"></WCSUrl>
-    <WFSLayers type="QStringList"></WFSLayers>
+    <WFSLayers type="QStringList"/>
     <WFSTLayers>
-      <Delete type="QStringList"></Delete>
-      <Insert type="QStringList"></Insert>
-      <Update type="QStringList"></Update>
+      <Delete type="QStringList"/>
+      <Insert type="QStringList"/>
+      <Update type="QStringList"/>
     </WFSTLayers>
     <WFSUrl type="QString"></WFSUrl>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
+    <WMSAddLayerGroupsLegendGraphic type="bool">false</WMSAddLayerGroupsLegendGraphic>
     <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
     <WMSContactMail type="QString"></WMSContactMail>
     <WMSContactOrganization type="QString">3liz</WMSContactOrganization>
@@ -2868,16 +3301,17 @@ def my_form_open(dialog, layer, feature):
     </WMSCrsList>
     <WMSDefaultMapUnitsPerMm type="double">1</WMSDefaultMapUnitsPerMm>
     <WMSExtent type="QStringList">
-      <value>3.8665670972281756</value>
-      <value>43.60787634971424609</value>
-      <value>3.87873159460366246</value>
-      <value>43.61985948078168462</value>
+      <value>3.8665670969999999</value>
+      <value>43.60787634999999796</value>
+      <value>3.87873159500000009</value>
+      <value>43.61985948099999888</value>
     </WMSExtent>
     <WMSFeatureInfoUseAttributeFormSettings type="bool">false</WMSFeatureInfoUseAttributeFormSettings>
     <WMSFees type="QString">conditions unknown</WMSFees>
     <WMSImageQuality type="int">90</WMSImageQuality>
     <WMSKeywordList type="QStringList">
-      <value></value>
+      <value>france</value>
+      <value>europe</value>
     </WMSKeywordList>
     <WMSMaxAtlasFeatures type="int">1</WMSMaxAtlasFeatures>
     <WMSOnlineResource type="QString">https://github.com/3liz/lizmap-mapbuilder-module</WMSOnlineResource>
@@ -2891,23 +3325,23 @@ def my_form_open(dialog, layer, feature):
     <WMSUrl type="QString"></WMSUrl>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
     <WMTSGrids>
-      <CRS type="QStringList"></CRS>
-      <Config type="QStringList"></Config>
+      <CRS type="QStringList"/>
+      <Config type="QStringList"/>
     </WMTSGrids>
     <WMTSJpegLayers>
-      <Group type="QStringList"></Group>
-      <Layer type="QStringList"></Layer>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
       <Project type="bool">false</Project>
     </WMTSJpegLayers>
     <WMTSLayers>
-      <Group type="QStringList"></Group>
-      <Layer type="QStringList"></Layer>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
       <Project type="bool">false</Project>
     </WMTSLayers>
     <WMTSMinScale type="int">5000</WMTSMinScale>
     <WMTSPngLayers>
-      <Group type="QStringList"></Group>
-      <Layer type="QStringList"></Layer>
+      <Group type="QStringList"/>
+      <Layer type="QStringList"/>
       <Project type="bool">false</Project>
     </WMTSPngLayers>
     <WMTSUrl type="QString"></WMTSUrl>
@@ -2927,13 +3361,13 @@ def my_form_open(dialog, layer, feature):
   </properties>
   <dataDefinedServerProperties>
     <Option type="Map">
-      <Option name="name" type="QString" value=""></Option>
-      <Option name="properties"></Option>
-      <Option name="type" type="QString" value="collection"></Option>
+      <Option name="name" value="" type="QString"/>
+      <Option name="properties"/>
+      <Option name="type" value="collection" type="QString"/>
     </Option>
   </dataDefinedServerProperties>
-  <visibility-presets></visibility-presets>
-  <transformContext></transformContext>
+  <visibility-presets/>
+  <transformContext/>
   <projectMetadata>
     <identifier></identifier>
     <parentidentifier></parentidentifier>
@@ -2950,18 +3384,23 @@ def my_form_open(dialog, layer, feature):
       <email></email>
       <role></role>
     </contact>
-    <links></links>
+    <links/>
+    <dates>
+      <date value="2021-09-28T15:53:22" type="Created"/>
+    </dates>
     <author>mdouchin</author>
     <creation>2021-09-28T15:53:22</creation>
   </projectMetadata>
-  <Annotations></Annotations>
-  <Layouts></Layouts>
-  <Bookmarks></Bookmarks>
-  <ProjectViewSettings UseProjectScales="0">
-    <Scales></Scales>
-    <DefaultViewExtent xmax="3.87873159460366246" xmin="3.8665670972281756" ymax="43.61985948078168462" ymin="43.60787634971424609">
-      <spatialrefsys>
-        <wkt>GEOGCRS["WGS 84",DATUM["World Geodetic System 1984",ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["unknown"],AREA["World"],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+  <Annotations/>
+  <Layouts/>
+  <mapViewDocks3D/>
+  <Bookmarks/>
+  <Sensors/>
+  <ProjectViewSettings UseProjectScales="0" rotation="0">
+    <Scales/>
+    <DefaultViewExtent xmax="3.88081332002806434" ymin="43.60909744558243517" xmin="3.86448537180377372" ymax="43.61863838491349554">
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
         <srsid>3452</srsid>
         <srid>4326</srid>
@@ -2973,19 +3412,58 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
-  <ProjectTimeSettings cumulativeTemporalRange="0" frameRate="1" timeStep="1" timeStepUnit="h"></ProjectTimeSettings>
-  <ProjectDisplaySettings>
+  <ProjectStyleSettings RandomizeDefaultSymbolColor="1" DefaultSymbolOpacity="1">
+    <databases/>
+  </ProjectStyleSettings>
+  <ProjectTimeSettings timeStepUnit="h" cumulativeTemporalRange="0" frameRate="1" timeStep="1"/>
+  <ElevationProperties>
+    <terrainProvider type="flat">
+      <TerrainProvider scale="1" offset="0"/>
+    </terrainProvider>
+  </ElevationProperties>
+  <ProjectDisplaySettings CoordinateType="MapCrs" CoordinateAxisOrder="Default">
     <BearingFormat id="bearing">
       <Option type="Map">
-        <Option name="decimal_separator" type="QChar" value=""></Option>
-        <Option name="decimals" type="int" value="6"></Option>
-        <Option name="direction_format" type="int" value="0"></Option>
-        <Option name="rounding_type" type="int" value="0"></Option>
-        <Option name="show_plus" type="bool" value="false"></Option>
-        <Option name="show_thousand_separator" type="bool" value="true"></Option>
-        <Option name="show_trailing_zeros" type="bool" value="false"></Option>
-        <Option name="thousand_separator" type="QChar" value=""></Option>
+        <Option name="decimal_separator" type="invalid"/>
+        <Option name="decimals" value="6" type="int"/>
+        <Option name="direction_format" value="0" type="int"/>
+        <Option name="rounding_type" value="0" type="int"/>
+        <Option name="show_plus" value="false" type="bool"/>
+        <Option name="show_thousand_separator" value="true" type="bool"/>
+        <Option name="show_trailing_zeros" value="false" type="bool"/>
+        <Option name="thousand_separator" type="invalid"/>
       </Option>
     </BearingFormat>
+    <GeographicCoordinateFormat id="geographiccoordinate">
+      <Option type="Map">
+        <Option name="angle_format" value="DecimalDegrees" type="QString"/>
+        <Option name="decimal_separator" type="invalid"/>
+        <Option name="decimals" value="6" type="int"/>
+        <Option name="rounding_type" value="0" type="int"/>
+        <Option name="show_leading_degree_zeros" value="false" type="bool"/>
+        <Option name="show_leading_zeros" value="false" type="bool"/>
+        <Option name="show_plus" value="false" type="bool"/>
+        <Option name="show_suffix" value="true" type="bool"/>
+        <Option name="show_thousand_separator" value="true" type="bool"/>
+        <Option name="show_trailing_zeros" value="false" type="bool"/>
+        <Option name="thousand_separator" type="invalid"/>
+      </Option>
+    </GeographicCoordinateFormat>
+    <CoordinateCustomCrs>
+      <spatialrefsys nativeFormat="Wkt">
+        <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>EPSG:7030</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </CoordinateCustomCrs>
   </ProjectDisplaySettings>
+  <ProjectGpsSettings destinationLayer="trees_bdb246a6_9321_490c_9f25_a7bfb7827cf9" autoAddTrackVertices="0" destinationFollowsActiveLayer="1" destinationLayerProvider="postgres" destinationLayerName="trees" autoCommitFeatures="0" destinationLayerSource="service='lizmap-mapbuilder' sslmode=disable key='id' estimatedmetadata=true srid=4326 type=Point checkPrimaryKeyUnicity='1' table=&quot;mapbuilder_demo&quot;.&quot;trees&quot; (geom)">
+    <timeStampFields/>
+  </ProjectGpsSettings>
 </qgis>

--- a/tests/lizmap/instances/testing_project/eastPoints.qgs
+++ b/tests/lizmap/instances/testing_project/eastPoints.qgs
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="" saveUserFull="Neo" saveDateTime="2025-02-18T12:36:56" version="3.34.4-Prizren" saveUser="neo">
+<qgis saveUser="neo" saveUserFull="Neo" saveDateTime="2025-02-25T15:31:25" projectname="" version="3.34.4-Prizren">
   <homePath path=""/>
   <title></title>
   <transaction mode="Disabled"/>
@@ -17,12 +17,12 @@
       <geographicflag>true</geographicflag>
     </spatialrefsys>
   </projectCrs>
-  <elevation-shading-renderer edl-strength="1000" hillshading-z-factor="1" is-active="0" edl-distance-unit="0" hillshading-is-multidirectional="0" light-altitude="45" light-azimuth="315" combined-method="0" hillshading-is-active="0" edl-distance="0.5" edl-is-active="1"/>
+  <elevation-shading-renderer light-azimuth="315" edl-distance-unit="0" hillshading-is-active="0" edl-is-active="1" hillshading-is-multidirectional="0" hillshading-z-factor="1" edl-distance="0.5" edl-strength="1000" light-altitude="45" is-active="0" combined-method="0"/>
   <layer-tree-group>
     <customproperties>
       <Option/>
     </customproperties>
-    <layer-tree-layer id="points_cbd657a2_d172_4318_86f9_36f02b7dcdee" name="points" patch_size="-1,-1" legend_exp="" source="./points.geojson" checked="Qt::Checked" providerKey="ogr" expanded="1" legend_split_behavior="0">
+    <layer-tree-layer expanded="1" legend_exp="" name="points" checked="Qt::Checked" patch_size="-1,-1" legend_split_behavior="0" id="points_cbd657a2_d172_4318_86f9_36f02b7dcdee" source="./points.geojson" providerKey="ogr">
       <customproperties>
         <Option/>
       </customproperties>
@@ -31,9 +31,9 @@
       <item>points_cbd657a2_d172_4318_86f9_36f02b7dcdee</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings maxScale="0" type="1" minScale="0" scaleDependencyMode="0" intersection-snapping="0" enabled="0" self-snapping="0" mode="2" tolerance="12" unit="1">
+  <snapping-settings minScale="0" tolerance="12" maxScale="0" enabled="0" intersection-snapping="0" mode="2" type="1" unit="1" self-snapping="0" scaleDependencyMode="0">
     <individual-layer-settings>
-      <layer-setting id="points_cbd657a2_d172_4318_86f9_36f02b7dcdee" maxScale="0" type="1" minScale="0" units="1" enabled="0" tolerance="12"/>
+      <layer-setting minScale="0" tolerance="12" maxScale="0" enabled="0" type="1" units="1" id="points_cbd657a2_d172_4318_86f9_36f02b7dcdee"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations/>
@@ -41,10 +41,10 @@
   <mapcanvas name="theMapCanvas" annotationsVisible="1">
     <units>degrees</units>
     <extent>
-      <xmin>20.8526030888934848</xmin>
-      <ymin>43.62275646465020884</ymin>
-      <xmax>20.89775352682748988</xmax>
-      <ymax>43.62275738071220132</ymax>
+      <xmin>20.85151994610234283</xmin>
+      <ymin>43.62116552354152077</ymin>
+      <xmax>20.90165874537490964</xmax>
+      <ymax>43.62116654081287948</ymax>
     </extent>
     <rotation>0</rotation>
     <destinationsrs>
@@ -65,14 +65,14 @@
   </mapcanvas>
   <projectModels/>
   <legend updateDrawingOrder="true">
-    <legendlayer name="points" open="true" showFeatureCount="0" checked="Qt::Checked" drawingOrder="-1">
-      <filegroup open="true" hidden="false">
-        <legendlayerfile visible="1" layerid="points_cbd657a2_d172_4318_86f9_36f02b7dcdee" isInOverview="0"/>
+    <legendlayer checked="Qt::Checked" name="points" drawingOrder="-1" open="true" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile layerid="points_cbd657a2_d172_4318_86f9_36f02b7dcdee" isInOverview="0" visible="1"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
-  <main-annotation-layer legendPlaceholderImage="" hasScaleBasedVisibilityFlag="0" maxScale="0" type="annotation" minScale="1e+08" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" styleCategories="AllStyleCategories" autoRefreshTime="0" autoRefreshMode="Disabled">
+  <main-annotation-layer minScale="1e+08" refreshOnNotifyMessage="" autoRefreshMode="Disabled" styleCategories="AllStyleCategories" maxScale="0" autoRefreshTime="0" type="annotation" hasScaleBasedVisibilityFlag="0" refreshOnNotifyEnabled="0" legendPlaceholderImage="">
     <id>Annotations_a789c14f_f2f8_49a2_b41f_d0cc496cc885</id>
     <datasource></datasource>
     <keywordList>
@@ -133,7 +133,7 @@
     <paintEffect/>
   </main-annotation-layer>
   <projectlayers>
-    <maplayer hasScaleBasedVisibilityFlag="0" symbologyReferenceScale="-1" simplifyDrawingTol="1" refreshOnNotifyEnabled="0" styleCategories="AllStyleCategories" autoRefreshTime="0" autoRefreshMode="Disabled" refreshOnNotifyMessage="" simplifyLocal="1" geometry="Point" maxScale="0" legendPlaceholderImage="" simplifyAlgorithm="0" readOnly="0" minScale="100000000" simplifyDrawingHints="0" type="vector" labelsEnabled="0" simplifyMaxScale="1" wkbType="Point">
+    <maplayer autoRefreshMode="Disabled" simplifyAlgorithm="0" minScale="100000000" simplifyLocal="1" legendPlaceholderImage="" readOnly="0" refreshOnNotifyEnabled="0" simplifyDrawingHints="0" refreshOnNotifyMessage="" maxScale="0" autoRefreshTime="0" wkbType="Point" simplifyMaxScale="1" geometry="Point" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" type="vector" simplifyDrawingTol="1" symbologyReferenceScale="-1" labelsEnabled="0">
       <extent>
         <xmin>20.8539999999999992</xmin>
         <ymin>43.62199999999999989</ymin>
@@ -200,7 +200,7 @@
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial dimensions="2" maxy="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" maxx="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" minz="0" crs="EPSG:4326" minx="179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" miny="179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" maxz="0"/>
+          <spatial minz="0" maxx="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" maxy="-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" crs="EPSG:4326" minx="179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" dimensions="2" miny="179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368" maxz="0"/>
           <temporal>
             <period>
               <start></start>
@@ -225,181 +225,181 @@
         <Searchable>1</Searchable>
         <Private>0</Private>
       </flags>
-      <temporal limitMode="0" accumulate="0" durationField="id" endExpression="" fixedDuration="0" durationUnit="min" enabled="0" startField="" endField="" mode="0" startExpression="">
+      <temporal startField="" accumulate="0" endField="" limitMode="0" durationUnit="min" enabled="0" fixedDuration="0" mode="0" durationField="id" endExpression="" startExpression="">
         <fixedRange>
           <start></start>
           <end></end>
         </fixedRange>
       </temporal>
-      <elevation extrusionEnabled="0" binding="Centroid" type="IndividualFeatures" zoffset="0" extrusion="0" symbology="Line" showMarkerSymbolInSurfacePlots="0" zscale="1" clamping="Terrain" respectLayerSymbol="1">
+      <elevation zoffset="0" respectLayerSymbol="1" extrusion="0" showMarkerSymbolInSurfacePlots="0" clamping="Terrain" symbology="Line" type="IndividualFeatures" zscale="1" binding="Centroid" extrusionEnabled="0">
         <data-defined-properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option name="name" value="" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </data-defined-properties>
         <profileLineSymbol>
-          <symbol is_animated="0" name="" type="line" alpha="1" frame_rate="10" force_rhr="0" clip_to_extent="1">
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option name="name" value="" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer id="{efd9aa8a-943b-4ae2-bf05-79b690713f58}" class="SimpleLine" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{efd9aa8a-943b-4ae2-bf05-79b690713f58}">
               <Option type="Map">
-                <Option name="align_dash_pattern" type="QString" value="0"/>
-                <Option name="capstyle" type="QString" value="square"/>
-                <Option name="customdash" type="QString" value="5;2"/>
-                <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="customdash_unit" type="QString" value="MM"/>
-                <Option name="dash_pattern_offset" type="QString" value="0"/>
-                <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-                <Option name="draw_inside_polygon" type="QString" value="0"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="line_color" type="QString" value="232,113,141,255"/>
-                <Option name="line_style" type="QString" value="solid"/>
-                <Option name="line_width" type="QString" value="0.6"/>
-                <Option name="line_width_unit" type="QString" value="MM"/>
-                <Option name="offset" type="QString" value="0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="ring_filter" type="QString" value="0"/>
-                <Option name="trim_distance_end" type="QString" value="0"/>
-                <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-                <Option name="trim_distance_start" type="QString" value="0"/>
-                <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-                <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-                <Option name="use_custom_dash" type="QString" value="0"/>
-                <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="align_dash_pattern" value="0" type="QString"/>
+                <Option name="capstyle" value="square" type="QString"/>
+                <Option name="customdash" value="5;2" type="QString"/>
+                <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="customdash_unit" value="MM" type="QString"/>
+                <Option name="dash_pattern_offset" value="0" type="QString"/>
+                <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                <Option name="draw_inside_polygon" value="0" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="line_color" value="232,113,141,255" type="QString"/>
+                <Option name="line_style" value="solid" type="QString"/>
+                <Option name="line_width" value="0.6" type="QString"/>
+                <Option name="line_width_unit" value="MM" type="QString"/>
+                <Option name="offset" value="0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="ring_filter" value="0" type="QString"/>
+                <Option name="trim_distance_end" value="0" type="QString"/>
+                <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                <Option name="trim_distance_start" value="0" type="QString"/>
+                <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                <Option name="use_custom_dash" value="0" type="QString"/>
+                <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileLineSymbol>
         <profileFillSymbol>
-          <symbol is_animated="0" name="" type="fill" alpha="1" frame_rate="10" force_rhr="0" clip_to_extent="1">
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="fill" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option name="name" value="" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer id="{f2391fa6-04a6-4624-9bb5-d3ba91c05cba}" class="SimpleFill" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleFill" id="{f2391fa6-04a6-4624-9bb5-d3ba91c05cba}">
               <Option type="Map">
-                <Option name="border_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="color" type="QString" value="232,113,141,255"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="166,81,101,255"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0.2"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="style" type="QString" value="solid"/>
+                <Option name="border_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="color" value="232,113,141,255" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="166,81,101,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="style" value="solid" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileFillSymbol>
         <profileMarkerSymbol>
-          <symbol is_animated="0" name="" type="marker" alpha="1" frame_rate="10" force_rhr="0" clip_to_extent="1">
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option name="name" value="" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer id="{1306b1ab-b334-40e2-9dc1-286acfea59e4}" class="SimpleMarker" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{1306b1ab-b334-40e2-9dc1-286acfea59e4}">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0"/>
-                <Option name="cap_style" type="QString" value="square"/>
-                <Option name="color" type="QString" value="232,113,141,255"/>
-                <Option name="horizontal_anchor_point" type="QString" value="1"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="name" type="QString" value="diamond"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="166,81,101,255"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0.2"/>
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="scale_method" type="QString" value="diameter"/>
-                <Option name="size" type="QString" value="3"/>
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="size_unit" type="QString" value="MM"/>
-                <Option name="vertical_anchor_point" type="QString" value="1"/>
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="232,113,141,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="diamond" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="166,81,101,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0.2" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="3" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MM" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
           </symbol>
         </profileMarkerSymbol>
       </elevation>
-      <renderer-v2 type="singleSymbol" symbollevels="0" forceraster="0" referencescale="-1" enableorderby="0">
+      <renderer-v2 forceraster="0" enableorderby="0" type="singleSymbol" symbollevels="0" referencescale="-1">
         <symbols>
-          <symbol is_animated="0" name="0" type="marker" alpha="1" frame_rate="10" force_rhr="0" clip_to_extent="1">
+          <symbol clip_to_extent="1" name="0" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option name="name" value="" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer id="{d8f7c6eb-81cf-424a-a23e-0e494d3e2700}" class="SimpleMarker" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{d8f7c6eb-81cf-424a-a23e-0e494d3e2700}">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0"/>
-                <Option name="cap_style" type="QString" value="square"/>
-                <Option name="color" type="QString" value="141,90,153,255"/>
-                <Option name="horizontal_anchor_point" type="QString" value="1"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="name" type="QString" value="circle"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="35,35,35,255"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0"/>
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="scale_method" type="QString" value="diameter"/>
-                <Option name="size" type="QString" value="15"/>
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="size_unit" type="QString" value="MM"/>
-                <Option name="vertical_anchor_point" type="QString" value="1"/>
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="141,90,153,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="35,35,35,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="15" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MM" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -411,41 +411,41 @@
       <selection mode="Default">
         <selectionColor invalid="1"/>
         <selectionSymbol>
-          <symbol is_animated="0" name="" type="marker" alpha="1" frame_rate="10" force_rhr="0" clip_to_extent="1">
+          <symbol clip_to_extent="1" name="" frame_rate="10" type="marker" force_rhr="0" is_animated="0" alpha="1">
             <data_defined_properties>
               <Option type="Map">
-                <Option name="name" type="QString" value=""/>
+                <Option name="name" value="" type="QString"/>
                 <Option name="properties"/>
-                <Option name="type" type="QString" value="collection"/>
+                <Option name="type" value="collection" type="QString"/>
               </Option>
             </data_defined_properties>
-            <layer id="{0d6a8206-46e3-436a-8dd3-d8acc6fe0bd1}" class="SimpleMarker" enabled="1" locked="0" pass="0">
+            <layer enabled="1" pass="0" locked="0" class="SimpleMarker" id="{0d6a8206-46e3-436a-8dd3-d8acc6fe0bd1}">
               <Option type="Map">
-                <Option name="angle" type="QString" value="0"/>
-                <Option name="cap_style" type="QString" value="square"/>
-                <Option name="color" type="QString" value="255,0,0,255"/>
-                <Option name="horizontal_anchor_point" type="QString" value="1"/>
-                <Option name="joinstyle" type="QString" value="bevel"/>
-                <Option name="name" type="QString" value="circle"/>
-                <Option name="offset" type="QString" value="0,0"/>
-                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="offset_unit" type="QString" value="MM"/>
-                <Option name="outline_color" type="QString" value="35,35,35,255"/>
-                <Option name="outline_style" type="QString" value="solid"/>
-                <Option name="outline_width" type="QString" value="0"/>
-                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="outline_width_unit" type="QString" value="MM"/>
-                <Option name="scale_method" type="QString" value="diameter"/>
-                <Option name="size" type="QString" value="2"/>
-                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                <Option name="size_unit" type="QString" value="MM"/>
-                <Option name="vertical_anchor_point" type="QString" value="1"/>
+                <Option name="angle" value="0" type="QString"/>
+                <Option name="cap_style" value="square" type="QString"/>
+                <Option name="color" value="255,0,0,255" type="QString"/>
+                <Option name="horizontal_anchor_point" value="1" type="QString"/>
+                <Option name="joinstyle" value="bevel" type="QString"/>
+                <Option name="name" value="circle" type="QString"/>
+                <Option name="offset" value="0,0" type="QString"/>
+                <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="offset_unit" value="MM" type="QString"/>
+                <Option name="outline_color" value="35,35,35,255" type="QString"/>
+                <Option name="outline_style" value="solid" type="QString"/>
+                <Option name="outline_width" value="0" type="QString"/>
+                <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="outline_width_unit" value="MM" type="QString"/>
+                <Option name="scale_method" value="diameter" type="QString"/>
+                <Option name="size" value="2" type="QString"/>
+                <Option name="size_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                <Option name="size_unit" value="MM" type="QString"/>
+                <Option name="vertical_anchor_point" value="1" type="QString"/>
               </Option>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -454,7 +454,7 @@
       </selection>
       <customproperties>
         <Option type="Map">
-          <Option name="embeddedWidgets/count" type="int" value="0"/>
+          <Option name="embeddedWidgets/count" value="0" type="int"/>
           <Option name="variableNames" type="invalid"/>
           <Option name="variableValues" type="invalid"/>
         </Option>
@@ -462,54 +462,54 @@
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
-        <DiagramCategory height="15" penAlpha="255" minimumSize="0" penColor="#000000" barWidth="5" diagramOrientation="Up" labelPlacementMethod="XHeight" rotationOffset="270" sizeType="MM" lineSizeType="MM" minScaleDenominator="0" backgroundColor="#ffffff" spacingUnitScale="3x:0,0,0,0,0,0" maxScaleDenominator="1e+08" scaleDependency="Area" opacity="1" sizeScale="3x:0,0,0,0,0,0" spacingUnit="MM" backgroundAlpha="255" direction="0" width="15" lineSizeScale="3x:0,0,0,0,0,0" showAxis="1" scaleBasedVisibility="0" spacing="5" enabled="0" penWidth="0">
-          <fontProperties strikethrough="0" underline="0" bold="0" style="" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
-          <attribute color="#000000" colorOpacity="1" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory scaleDependency="Area" sizeType="MM" spacingUnit="MM" direction="0" height="15" rotationOffset="270" barWidth="5" scaleBasedVisibility="0" penColor="#000000" minimumSize="0" spacingUnitScale="3x:0,0,0,0,0,0" backgroundAlpha="255" showAxis="1" opacity="1" minScaleDenominator="0" penAlpha="255" width="15" enabled="0" penWidth="0" diagramOrientation="Up" spacing="5" lineSizeType="MM" labelPlacementMethod="XHeight" maxScaleDenominator="1e+08" backgroundColor="#ffffff" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0">
+          <fontProperties bold="0" italic="0" description="Ubuntu,11,-1,5,50,0,0,0,0,0" underline="0" style="" strikethrough="0"/>
+          <attribute field="" color="#000000" label="" colorOpacity="1"/>
           <axisSymbol>
-            <symbol is_animated="0" name="" type="line" alpha="1" frame_rate="10" force_rhr="0" clip_to_extent="1">
+            <symbol clip_to_extent="1" name="" frame_rate="10" type="line" force_rhr="0" is_animated="0" alpha="1">
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" type="QString" value=""/>
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties"/>
-                  <Option name="type" type="QString" value="collection"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
-              <layer id="{6246451d-9a1d-4620-8ec5-2389a77a22c3}" class="SimpleLine" enabled="1" locked="0" pass="0">
+              <layer enabled="1" pass="0" locked="0" class="SimpleLine" id="{6246451d-9a1d-4620-8ec5-2389a77a22c3}">
                 <Option type="Map">
-                  <Option name="align_dash_pattern" type="QString" value="0"/>
-                  <Option name="capstyle" type="QString" value="square"/>
-                  <Option name="customdash" type="QString" value="5;2"/>
-                  <Option name="customdash_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="customdash_unit" type="QString" value="MM"/>
-                  <Option name="dash_pattern_offset" type="QString" value="0"/>
-                  <Option name="dash_pattern_offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="dash_pattern_offset_unit" type="QString" value="MM"/>
-                  <Option name="draw_inside_polygon" type="QString" value="0"/>
-                  <Option name="joinstyle" type="QString" value="bevel"/>
-                  <Option name="line_color" type="QString" value="35,35,35,255"/>
-                  <Option name="line_style" type="QString" value="solid"/>
-                  <Option name="line_width" type="QString" value="0.26"/>
-                  <Option name="line_width_unit" type="QString" value="MM"/>
-                  <Option name="offset" type="QString" value="0"/>
-                  <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="offset_unit" type="QString" value="MM"/>
-                  <Option name="ring_filter" type="QString" value="0"/>
-                  <Option name="trim_distance_end" type="QString" value="0"/>
-                  <Option name="trim_distance_end_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="trim_distance_end_unit" type="QString" value="MM"/>
-                  <Option name="trim_distance_start" type="QString" value="0"/>
-                  <Option name="trim_distance_start_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
-                  <Option name="trim_distance_start_unit" type="QString" value="MM"/>
-                  <Option name="tweak_dash_pattern_on_corners" type="QString" value="0"/>
-                  <Option name="use_custom_dash" type="QString" value="0"/>
-                  <Option name="width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                  <Option name="align_dash_pattern" value="0" type="QString"/>
+                  <Option name="capstyle" value="square" type="QString"/>
+                  <Option name="customdash" value="5;2" type="QString"/>
+                  <Option name="customdash_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="customdash_unit" value="MM" type="QString"/>
+                  <Option name="dash_pattern_offset" value="0" type="QString"/>
+                  <Option name="dash_pattern_offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="dash_pattern_offset_unit" value="MM" type="QString"/>
+                  <Option name="draw_inside_polygon" value="0" type="QString"/>
+                  <Option name="joinstyle" value="bevel" type="QString"/>
+                  <Option name="line_color" value="35,35,35,255" type="QString"/>
+                  <Option name="line_style" value="solid" type="QString"/>
+                  <Option name="line_width" value="0.26" type="QString"/>
+                  <Option name="line_width_unit" value="MM" type="QString"/>
+                  <Option name="offset" value="0" type="QString"/>
+                  <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="offset_unit" value="MM" type="QString"/>
+                  <Option name="ring_filter" value="0" type="QString"/>
+                  <Option name="trim_distance_end" value="0" type="QString"/>
+                  <Option name="trim_distance_end_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_end_unit" value="MM" type="QString"/>
+                  <Option name="trim_distance_start" value="0" type="QString"/>
+                  <Option name="trim_distance_start_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+                  <Option name="trim_distance_start_unit" value="MM" type="QString"/>
+                  <Option name="tweak_dash_pattern_on_corners" value="0" type="QString"/>
+                  <Option name="use_custom_dash" value="0" type="QString"/>
+                  <Option name="width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
                 </Option>
                 <data_defined_properties>
                   <Option type="Map">
-                    <Option name="name" type="QString" value=""/>
+                    <Option name="name" value="" type="QString"/>
                     <Option name="properties"/>
-                    <Option name="type" type="QString" value="collection"/>
+                    <Option name="type" value="collection" type="QString"/>
                   </Option>
                 </data_defined_properties>
               </layer>
@@ -517,30 +517,30 @@
           </axisSymbol>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings dist="0" zIndex="0" linePlacementFlags="18" obstacle="0" placement="0" priority="0" showAll="1">
+      <DiagramLayerSettings priority="0" dist="0" showAll="1" linePlacementFlags="18" obstacle="0" placement="0" zIndex="0">
         <properties>
           <Option type="Map">
-            <Option name="name" type="QString" value=""/>
+            <Option name="name" value="" type="QString"/>
             <Option name="properties"/>
-            <Option name="type" type="QString" value="collection"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
-      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+      <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
         <activeChecks/>
         <checkConfiguration/>
       </geometryOptions>
-      <legend type="default-vector" showLabelLegend="0"/>
+      <legend showLabelLegend="0" type="default-vector"/>
       <referencedLayers/>
       <fieldConfiguration>
-        <field name="id" configurationFlags="NoFlag">
+        <field configurationFlags="NoFlag" name="id">
           <editWidget type="Range">
             <config>
               <Option/>
             </config>
           </editWidget>
         </field>
-        <field name="name" configurationFlags="NoFlag">
+        <field configurationFlags="NoFlag" name="name">
           <editWidget type="TextEdit">
             <config>
               <Option/>
@@ -549,34 +549,34 @@
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias name="" index="0" field="id"/>
-        <alias name="" index="1" field="name"/>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="name" index="1"/>
       </aliases>
       <splitPolicies>
-        <policy policy="Duplicate" field="id"/>
-        <policy policy="Duplicate" field="name"/>
+        <policy field="id" policy="Duplicate"/>
+        <policy field="name" policy="Duplicate"/>
       </splitPolicies>
       <defaults>
-        <default applyOnUpdate="0" expression="" field="id"/>
-        <default applyOnUpdate="0" expression="" field="name"/>
+        <default field="id" applyOnUpdate="0" expression=""/>
+        <default field="name" applyOnUpdate="0" expression=""/>
       </defaults>
       <constraints>
-        <constraint unique_strength="0" field="id" constraints="0" notnull_strength="0" exp_strength="0"/>
-        <constraint unique_strength="0" field="name" constraints="0" notnull_strength="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="id" unique_strength="0" constraints="0" exp_strength="0"/>
+        <constraint notnull_strength="0" field="name" unique_strength="0" constraints="0" exp_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="id" desc=""/>
-        <constraint exp="" field="name" desc=""/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="name" exp=""/>
       </constraintExpressions>
       <expressionfields/>
       <attributeactions>
         <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
       </attributeactions>
-      <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
         <columns>
-          <column name="id" type="field" hidden="0" width="-1"/>
-          <column name="name" type="field" hidden="0" width="-1"/>
-          <column type="actions" hidden="1" width="-1"/>
+          <column name="id" hidden="0" type="field" width="-1"/>
+          <column name="name" hidden="0" type="field" width="-1"/>
+          <column hidden="1" type="actions" width="-1"/>
         </columns>
       </attributetableconfig>
       <conditionalstyles>
@@ -724,7 +724,9 @@ def my_form_open(dialog, layer, feature):
     <WMSFees type="QString">conditions unknown</WMSFees>
     <WMSImageQuality type="int">90</WMSImageQuality>
     <WMSKeywordList type="QStringList">
-      <value></value>
+      <value>europe</value>
+      <value>dots</value>
+      <value>east</value>
     </WMSKeywordList>
     <WMSMaxAtlasFeatures type="int">1</WMSMaxAtlasFeatures>
     <WMSOnlineResource type="QString"></WMSOnlineResource>
@@ -761,9 +763,9 @@ def my_form_open(dialog, layer, feature):
   </properties>
   <dataDefinedServerProperties>
     <Option type="Map">
-      <Option name="name" type="QString" value=""/>
+      <Option name="name" value="" type="QString"/>
       <Option name="properties"/>
-      <Option name="type" type="QString" value="collection"/>
+      <Option name="type" value="collection" type="QString"/>
     </Option>
   </dataDefinedServerProperties>
   <visibility-presets/>
@@ -786,7 +788,7 @@ def my_form_open(dialog, layer, feature):
     </contact>
     <links/>
     <dates>
-      <date type="Created" value="2025-02-17T17:18:39"/>
+      <date value="2025-02-17T17:18:39" type="Created"/>
     </dates>
     <author>Neo</author>
     <creation>2025-02-17T17:18:39</creation>
@@ -798,7 +800,7 @@ def my_form_open(dialog, layer, feature):
   <Sensors/>
   <ProjectViewSettings UseProjectScales="0" rotation="0">
     <Scales/>
-    <DefaultViewExtent ymin="43.61075969818406861" xmax="20.89775352682748988" xmin="20.8526030888934848" ymax="43.63475414717834155">
+    <DefaultViewExtent xmax="20.90165874537490964" ymin="43.60651718483212846" xmin="20.85151994610234283" ymax="43.63581487952227178">
       <spatialrefsys nativeFormat="Wkt">
         <wkt>GEOGCRS["WGS 84",ENSEMBLE["World Geodetic System 1984 ensemble",MEMBER["World Geodetic System 1984 (Transit)"],MEMBER["World Geodetic System 1984 (G730)"],MEMBER["World Geodetic System 1984 (G873)"],MEMBER["World Geodetic System 1984 (G1150)"],MEMBER["World Geodetic System 1984 (G1674)"],MEMBER["World Geodetic System 1984 (G1762)"],MEMBER["World Geodetic System 1984 (G2139)"],ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1]],ENSEMBLEACCURACY[2.0]],PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],CS[ellipsoidal,2],AXIS["geodetic latitude (Lat)",north,ORDER[1],ANGLEUNIT["degree",0.0174532925199433]],AXIS["geodetic longitude (Lon)",east,ORDER[2],ANGLEUNIT["degree",0.0174532925199433]],USAGE[SCOPE["Horizontal component of 3D system."],AREA["World."],BBOX[-90,-180,90,180]],ID["EPSG",4326]]</wkt>
         <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
@@ -812,40 +814,40 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </DefaultViewExtent>
   </ProjectViewSettings>
-  <ProjectStyleSettings DefaultSymbolOpacity="1" projectStyleId="attachment:///zgIrrg_styles.db" RandomizeDefaultSymbolColor="1">
+  <ProjectStyleSettings RandomizeDefaultSymbolColor="1" projectStyleId="attachment:///qBYDdd_styles.db" DefaultSymbolOpacity="1">
     <databases/>
   </ProjectStyleSettings>
-  <ProjectTimeSettings frameRate="1" timeStepUnit="h" timeStep="1" cumulativeTemporalRange="0"/>
+  <ProjectTimeSettings timeStepUnit="h" cumulativeTemporalRange="0" frameRate="1" timeStep="1"/>
   <ElevationProperties>
     <terrainProvider type="flat">
-      <TerrainProvider offset="0" scale="1"/>
+      <TerrainProvider scale="1" offset="0"/>
     </terrainProvider>
   </ElevationProperties>
-  <ProjectDisplaySettings CoordinateAxisOrder="Default" CoordinateType="MapCrs">
+  <ProjectDisplaySettings CoordinateType="MapCrs" CoordinateAxisOrder="Default">
     <BearingFormat id="bearing">
       <Option type="Map">
         <Option name="decimal_separator" type="invalid"/>
-        <Option name="decimals" type="int" value="6"/>
-        <Option name="direction_format" type="int" value="0"/>
-        <Option name="rounding_type" type="int" value="0"/>
-        <Option name="show_plus" type="bool" value="false"/>
-        <Option name="show_thousand_separator" type="bool" value="true"/>
-        <Option name="show_trailing_zeros" type="bool" value="false"/>
+        <Option name="decimals" value="6" type="int"/>
+        <Option name="direction_format" value="0" type="int"/>
+        <Option name="rounding_type" value="0" type="int"/>
+        <Option name="show_plus" value="false" type="bool"/>
+        <Option name="show_thousand_separator" value="true" type="bool"/>
+        <Option name="show_trailing_zeros" value="false" type="bool"/>
         <Option name="thousand_separator" type="invalid"/>
       </Option>
     </BearingFormat>
     <GeographicCoordinateFormat id="geographiccoordinate">
       <Option type="Map">
-        <Option name="angle_format" type="QString" value="DecimalDegrees"/>
+        <Option name="angle_format" value="DecimalDegrees" type="QString"/>
         <Option name="decimal_separator" type="invalid"/>
-        <Option name="decimals" type="int" value="6"/>
-        <Option name="rounding_type" type="int" value="0"/>
-        <Option name="show_leading_degree_zeros" type="bool" value="false"/>
-        <Option name="show_leading_zeros" type="bool" value="false"/>
-        <Option name="show_plus" type="bool" value="false"/>
-        <Option name="show_suffix" type="bool" value="false"/>
-        <Option name="show_thousand_separator" type="bool" value="true"/>
-        <Option name="show_trailing_zeros" type="bool" value="false"/>
+        <Option name="decimals" value="6" type="int"/>
+        <Option name="rounding_type" value="0" type="int"/>
+        <Option name="show_leading_degree_zeros" value="false" type="bool"/>
+        <Option name="show_leading_zeros" value="false" type="bool"/>
+        <Option name="show_plus" value="false" type="bool"/>
+        <Option name="show_suffix" value="false" type="bool"/>
+        <Option name="show_thousand_separator" value="true" type="bool"/>
+        <Option name="show_trailing_zeros" value="false" type="bool"/>
         <Option name="thousand_separator" type="invalid"/>
       </Option>
     </GeographicCoordinateFormat>
@@ -863,7 +865,7 @@ def my_form_open(dialog, layer, feature):
       </spatialrefsys>
     </CoordinateCustomCrs>
   </ProjectDisplaySettings>
-  <ProjectGpsSettings destinationLayerName="points" autoAddTrackVertices="0" destinationLayer="points_cbd657a2_d172_4318_86f9_36f02b7dcdee" destinationLayerSource="/home/neo/Documents/Alternance/lizmap-mapbuilder-module/tests/lizmap/instances/testing_project/points.geojson" autoCommitFeatures="0" destinationLayerProvider="ogr" destinationFollowsActiveLayer="1">
+  <ProjectGpsSettings destinationLayer="points_cbd657a2_d172_4318_86f9_36f02b7dcdee" autoAddTrackVertices="0" destinationFollowsActiveLayer="1" destinationLayerProvider="ogr" destinationLayerName="points" autoCommitFeatures="0" destinationLayerSource="/home/neo/Documents/Alternance/lizmap-mapbuilder-module/tests/lizmap/instances/testing_project/points.geojson">
     <timeStampFields/>
   </ProjectGpsSettings>
 </qgis>


### PR DESCRIPTION
Improvement for the layer-store from #55  :

* Now we can filter printed layers by their keywords.
* **Union** or **Intersection** for filtering.
* We can search through all keywords wit an input.
* **Added** some E2E tests.

## Example :

In this example, both projects "Cats" and "Lampadaires" are loaded by clicking on them :

- **norwayPoints** : 
   - Location : _Norway_
   - Keywords : _infoMapAccessService, nord, europe, dot_
- **Project demo**
   - Location : _Montpellier_
   - Keywords : _infoMapAccessService, france, europe_
- **eastPoints**
   - Location : _Serbia_
   - Keywords : _infoMapAccessService, europe, dots, east_
- **Paris**
   - Location : _Paris_
   - Keywords : _infoMapAccessService, france, europe_

https://github.com/user-attachments/assets/26fcf618-c8f1-418b-ba87-4e2388b5c894
