### PR TITLE
Improved the way to filter by extent

### DIFF
--- a/mapBuilder/www/js/components/LayerStore.js
+++ b/mapBuilder/www/js/components/LayerStore.js
@@ -196,6 +196,7 @@ export class LayerStore extends HTMLElement {
                 updateChildrenAttributes(children, element);
                 element.createChildren(children);
                 element.changeStatusFolder();
+                element.loadBbox();
             } else {
                 element.setFailed();
             }

--- a/mapBuilder/www/js/modules/Filter/FilterExtent.js
+++ b/mapBuilder/www/js/modules/Filter/FilterExtent.js
@@ -17,27 +17,7 @@ export class ExtentFilter extends AbstractFilter {
      * @param {import("../LayerTree/LayerTreeElement").LayerTreeElement} layerTreeElement - The layer tree element to be filtered.
      */
     filterProj(layerTreeElement) {
-        this.recFilter(layerTreeElement);
-    }
-
-    /**
-     * Recursive function to filter a layer.
-     * @param {import("../LayerTree/LayerTreeElement").LayerTreeElement} layerTreeElement - Layer tree element to filter.
-     * @returns {boolean} - true if the filter has been calculated. Otherwise, false.
-     */
-    recFilter(layerTreeElement) {
-        if (layerTreeElement.getBbox()) {
-            this.calculateFilter(layerTreeElement);
-            return true;
-        } else if (layerTreeElement.hasChildren()) {
-            let children = layerTreeElement.getChildren();
-            for (let i = 0; i < children.length; i++) {
-                if (this.recFilter(children[i])) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        this.calculateFilter(layerTreeElement);
     }
 
     /**

--- a/mapBuilder/www/js/modules/LayerTree/LayerTreeElement.js
+++ b/mapBuilder/www/js/modules/LayerTree/LayerTreeElement.js
@@ -137,4 +137,12 @@ export class LayerTreeElement {
     getColor() {
         return this._color;
     }
+
+    /**
+     * Sets the bounding box value for the object.
+     * @param {import("ol/extent").Extent} bbox - The bounding box to be set.
+     */
+    setBbox(bbox) {
+        this._bbox = bbox;
+    }
 }


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
* Better way to filter by extent by using a `extend` of every extent instead of using only one extent from all layers from a project.

## Before

When a **project** load multiple layers, each ones has their specific `bbox`.

![page1 drawio](https://github.com/user-attachments/assets/dd127b87-bbf8-4bf1-9837-3d1c2ca0595a)

We set the **Extent filter** on and we try to navigate on the project. If we hover the place where, at least, one layer should be, the `LayerStore` will still be filled of the **project**.

![page2 drawio](https://github.com/user-attachments/assets/67478034-8e58-4baf-9813-9dce4abe4a44)

But, once we hover another layer than the **first one** located in the **project**, the **project** disappears from the `LayerStore`.

![page3 drawio](https://github.com/user-attachments/assets/c1b8afc7-2038-4fa8-ae22-b2c1c4fdd5c1)

In fact, once the **Extent filter** is set on, it uses the `bbox` from the first layer that appears in the **project**.

## Now

Now, once a **project** is loaded, _mapBuilder_ calculate a **"_project bbox_"** that will be associated with its **project**. 

![page4 drawio](https://github.com/user-attachments/assets/add8c0fe-b6b4-451b-b11e-d0cf1be29dd3)

Thanks to this change, `LayerStore` can still be filled with the **project** no matter which layer we are hovering.

![page5 drawio](https://github.com/user-attachments/assets/92614266-7efe-462c-9152-a89fedffc1cb)
