### PR TITLE
FIX: Front updated when loading a saved map

### DIFF
--- a/mapBuilder/www/js/main.js
+++ b/mapBuilder/www/js/main.js
@@ -25,7 +25,7 @@ import {always as alwaysCondition, shiftKeyOnly as shiftKeyOnlyCondition} from '
 import './modules/bottom-dock.js';
 
 import {LayerStore} from "./components/LayerStore";
-import {addElementToLayerArray} from "./modules/LayerSelection/LayerSelection.js";
+import {addElementToLayerArray, updateFromLayerTree} from "./modules/LayerSelection/LayerSelection.js";
 import {CustomProgress} from "./components/inkmap/ProgressBar";
 import {FlashMessage} from "./components/FlashMessage"
 
@@ -97,6 +97,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     /**
      * Refresh the layerSelected tree to reflect OL layer's state
+     * @returns {Array} An array of layer objects representing the selected layers in the map, organized by z-index.
      */
     function refreshLayerSelected() {
         var layerTree = [];
@@ -106,6 +107,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 var layerObject = {
                     repositoryId: layer.getProperties().repositoryId,
                     projectId: layer.getProperties().projectId,
+                    projectName: layer.getProperties().projectName,
+                    elementColor: layer.getProperties().elementColor,
                     title: layer.getProperties().title,
                     styles: layer.getSource().getParams().STYLES,
                     hasAttributeTable: layer.getProperties().hasAttributeTable,
@@ -126,6 +129,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Refresh legends
         loadLegend();
+
+        return layerTree;
     }
 
     var dragZoomControl = class DragZoomControl extends Control {
@@ -663,6 +668,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 document.querySelector("#layers-loading > .spinner-grow:first-child").remove();
             });
 
+            newLayer.setProperties({"elementColor": element.style.backgroundColor});
+
             mapBuilder.map.addLayer(newLayer);
             refreshLayerSelected();
 
@@ -890,6 +897,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     title: layerProperties.title,
                     repositoryId: layerProperties.repositoryId,
                     projectId: layerProperties.projectId,
+                    projectName: layerProperties.projectName,
+                    elementColor: layerProperties.elementColor,
                     opacity: layerProperties.opacity,
                     bbox: layerProperties.bbox,
                     popup: layerProperties.popup,
@@ -964,6 +973,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     mapBuilder.map.getView().setCenter(mapcontext.center);
                     mapBuilder.map.getView().setZoom(mapcontext.zoom);
 
+                    let layerTree = [];
+
                     // Load layers if present
                     if(mapcontext.layers.length > 0){
                         for (var k = 0; k < mapcontext.layers.length; k++) {
@@ -973,6 +984,8 @@ document.addEventListener('DOMContentLoaded', () => {
                                 title: layerContext.title,
                                 repositoryId: layerContext.repositoryId,
                                 projectId: layerContext.projectId,
+                                projectName: layerContext.projectName,
+                                elementColor: layerContext.elementColor,
                                 opacity: layerContext.opacity,
                                 bbox: layerContext.bbox,
                                 popup: layerContext.popup,
@@ -992,8 +1005,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
                             mapBuilder.map.addLayer(newLayer);
                         }
-                        refreshLayerSelected();
+                        layerTree = refreshLayerSelected();
                     }
+                    updateFromLayerTree(layerTree)
                 }
             });
 

--- a/mapBuilder/www/js/modules/LayerSelection/LayerSelection.js
+++ b/mapBuilder/www/js/modules/LayerSelection/LayerSelection.js
@@ -59,6 +59,55 @@ export function addElementToLayerArray(value, color) {
 }
 
 /**
+ * Removes all layers from the layerArray and corresponding DOM elements.
+ */
+function removeAll() {
+    let listUID = [];
+
+    layerArray.getArray().forEach(function (layer) {
+        listUID.push(layer.getUid());
+    });
+
+    listUID.forEach(function (uid) {
+        document.getElementById("layer_" + uid).remove();
+        layerArray.removeElement(uid);
+    });
+}
+
+/**
+ * Retrieves a layer from the collection of layers by its unique identifier (uid).
+ * @param {string} uid - The unique identifier of the layer to retrieve.
+ * @returns {object|null} The layer object associated with the given uid, or null if no matching layer is found.
+ */
+function getLayerFromUid(uid) {
+    const allLayers = mapBuilder.map.getAllLayers();
+
+    for (let i = 0; i < allLayers.length; i++) {
+        if (allLayers[i].ol_uid === uid) {
+            return allLayers[i];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Updates the layers based on the provided `layerTree` structure.
+ * This method clears all existing layers and updates the LaerStore
+ * by adding elements with corresponding colors to the layer array.
+ * @param {Array} layerTree - An array representing the structure of the layer tree.
+ */
+export function updateFromLayerTree(layerTree) {
+    removeAll();
+
+    layerTree.reverse()
+
+    layerTree.forEach(function (layer) {
+        addElementToLayerArray(getLayerFromUid(layer.ol_uid), layer.elementColor);
+    });
+}
+
+/**
  * Used to get the index of the layer where the user dropped the dragged layer.
  * @param {HTMLElement} layers Represents the "layer-selected-holder" div.
  * @param {number} y Y coordinate of the drop.

--- a/tests/e2e/tests/mapbuilder.spec.js
+++ b/tests/e2e/tests/mapbuilder.spec.js
@@ -158,4 +158,34 @@ test.describe('Build with multiple layers', () => {
         await expect(page.getByRole('listitem').filter({ hasText: 'Project demo' })).toBeVisible();
         await expect(page.getByRole('listitem').filter({ hasText: 'Paris' })).toBeVisible();
     });
+
+    test('Handle map save', async ({ page }) => {
+        const footwaysEl = await page.getByRole('listitem').filter({ hasText: 'Mapbuilder' }).locator('div');
+
+        const footwaysBgColor = await footwaysEl.evaluate(el => window.getComputedStyle(el).backgroundColor);
+
+        const lizmapMapbuilderMainPage = new LizmapMapbuilderMainPage(page);
+        await lizmapMapbuilderMainPage.openMyMapsDock();
+
+        await page.waitForTimeout(250);
+
+        await lizmapMapbuilderMainPage.mapTitleInput.fill("map");
+        await lizmapMapbuilderMainPage.saveMapContextButton.click();
+
+        await page.locator(".btn-mapcontext-run");
+
+        await lizmapMapbuilderMainPage.openSelectedLayersDock();
+
+        await page.waitForTimeout(250);
+
+        const amountSelected = await lizmapMapbuilderMainPage.selectedLayerHolder.locator("lizmap-layer-selected").count();
+
+        const firstEl = await lizmapMapbuilderMainPage.selectedLayerHolder.locator("lizmap-layer-selected").nth(0).locator(".change-order-container");
+
+        const firstElBgColor = await firstEl.evaluate(el => window.getComputedStyle(el).backgroundColor);
+
+        await expect(amountSelected).toEqual(2);
+        await expect(footwaysBgColor).toEqual(firstElBgColor);
+
+    });
 });


### PR DESCRIPTION
Since the update of the **front** about `LayerSelected`, when we would save a map and load it, the selected layers in the dock weren't updated.
Now, layers are well showed according to the saved map.
* Added the `projectName` value and `color` too
* Added e2e test