### PR TITLE
Compatibility with Lizmap 3.9

### DIFF
--- a/mapBuilderAdmin/forms/config.form.xml
+++ b/mapBuilderAdmin/forms/config.form.xml
@@ -11,12 +11,12 @@
     </menulist>
 
     <input ref="extent" type="string" pattern="/^-?\d{1,3}\.?\d*,-?\d{1,2}\.?\d*,-?\d{1,3}\.?\d*,-?\d{1,2}\.?\d*$/">
-      <label locale="view~default.project.bbox.label" />
+      <label locale="mapBuilderAdmin~admin.form.extent.label" />
       <help locale="mapBuilderAdmin~admin.form.extent.help" />
     </input>
 
     <checkboxes ref="baseLayer" required="true">
-      <label locale="view~map.baselayermenu.title" />
+      <label locale="mapBuilderAdmin~admin.form.baselayermenu.label" />
       <datasource class="mapBuilder~listBaseLayer" />
     </checkboxes>
 

--- a/mapBuilderAdmin/locales/en_US/admin.UTF-8.properties
+++ b/mapBuilderAdmin/locales/en_US/admin.UTF-8.properties
@@ -7,3 +7,6 @@ form.baselayer.default=Default base layer
 form.baselayer.key.bing=Bing API key
 form.baselayer.key.ign=IGN API key
 form.attribute.isactive=Attribute table tool
+
+form.extent.label=Bounding Box
+form.baselayermenu.label=Base Layer

--- a/mapBuilderAdmin/locales/fr_FR/admin.UTF-8.properties
+++ b/mapBuilderAdmin/locales/fr_FR/admin.UTF-8.properties
@@ -7,3 +7,6 @@ form.baselayer.default=Fond de carte par défaut
 form.baselayer.key.bing=Clé API Bing
 form.baselayer.key.ign=Clé API IGN
 form.attribute.isactive=Outil table attributaire
+
+form.extent.label=Cadre de délimitation
+form.baselayermenu.label=Fond de carte

--- a/mapBuilderAdmin/locales/pt_PT/admin.UTF-8.properties
+++ b/mapBuilderAdmin/locales/pt_PT/admin.UTF-8.properties
@@ -7,3 +7,6 @@ form.baselayer.default=Camada base padrão
 form.baselayer.key.bing=Chave da API Bing
 form.baselayer.key.ign=Chave da API IGN
 form.attribute.isactive=Ferramenta de tabela de atributos
+
+form.extent.label=Caixa delimitadora
+form.baselayermenu.label=Fundo do mapa

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,7 @@ LIZMAP_DIR=$(shell pwd)/lizmap
 LIZMAP_USER_ID:=$(shell id -u)
 LIZMAP_USER_GID:=$(shell id -g)
 
-LIZMAP_VERSION_TAG:=3.8
+LIZMAP_VERSION_TAG:=3.9
 QGIS_VERSION_TAG:=ltr-rc
 POSTGIS_VERSION_TAG:=15-3
 


### PR DESCRIPTION
Replaced some locals that where in the [view module](https://github.com/3liz/lizmap-web-client/blob/34ea7d8ffea7c97af55f27c789c14f8cc7f01d9f/lizmap/modules/view/locales/en_US/default.UTF-8.properties) located in LWC code.

To avoid conflict by [removing some](https://github.com/3liz/lizmap-web-client/commit/34ea7d8ffea7c97af55f27c789c14f8cc7f01d9f), I moved two string directly in the module.